### PR TITLE
Improve speaker updating flow

### DIFF
--- a/R/00_sched-api.R
+++ b/R/00_sched-api.R
@@ -51,3 +51,19 @@ sched_upsert <- function(data, type, write_key, list_key = write_key) {
   stop_for_errors(ret, glue::glue("sched upsert to `{type}/[mod,add]`"))
   invisible(purrr::map(ret, "results"))
 }
+
+sched_user_mod_speaker_role <- function(username, sessions, action = "add") {
+  stopifnot(
+    "one user at a time" = length(username) == 1,
+    "action is 'add' or 'del'" = action %in% c("add", "del")
+  )
+
+  params <- list(
+    username = username,
+    sessions = paste(sessions, collapse = ","),
+    role = "speaker",
+    send_email = 0
+  )
+
+  sched_POST(glue::glue("role/{action}"), params)
+}

--- a/R/01_talks.R
+++ b/R/01_talks.R
@@ -2,11 +2,8 @@
 # https://rstudioconf2022.sched.com/editor
 # https://sched.com/api
 
-# TODO: figure out what's wrong here (needs unique suffix?)
-#   ✖ colin_gillespie: ERR: Username already exists, choose another one.
-#   ✖ david_smith: ERR: Username already exists, choose another one.
+# TODO: Nick has previously signed into sched
 #   ✖ nick_strayer: ERR: Username already exists, choose another one.
-# TODO: ✖ david_robinson: ERR: Email already exists, choose another one.
 # TODO: replace generic track names with real room names
 
 library(lubridate)

--- a/R/01_talks.R
+++ b/R/01_talks.R
@@ -99,7 +99,7 @@ sched_upsert(program_sched, "session", "session_key", "event_key")
 speaker_sched <-
   speakers |>
   transmute(
-    username = username |> str_replace_all("-", "_") |> iconv(to = "ASCII//translit"),
+    username = username,
     role = "speaker",
     full_name = name,
     company = affiliation,

--- a/R/01_talks.R
+++ b/R/01_talks.R
@@ -2,8 +2,6 @@
 # https://rstudioconf2022.sched.com/editor
 # https://sched.com/api
 
-# TODO: Nick has previously signed into sched
-#   ✖ nick_strayer: ERR: Username already exists, choose another one.
 # TODO: replace generic track names with real room names
 
 library(lubridate)

--- a/R/01_talks.R
+++ b/R/01_talks.R
@@ -99,7 +99,7 @@ sched_upsert(program_sched, "session", "session_key", "event_key")
 speaker_sched <-
   speakers |>
   transmute(
-    username = slug |> str_replace_all("-", "_") |> iconv(to = "ASCII//translit"),
+    username = username |> str_replace_all("-", "_") |> iconv(to = "ASCII//translit"),
     role = "speaker",
     full_name = name,
     company = affiliation,

--- a/sessions/advanced-r/cracking-open-ggplot-internals-ggtrace.md
+++ b/sessions/advanced-r/cracking-open-ggplot-internals-ggtrace.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/yjunechoe/ggtrace
     linkedin: ~
     affiliation: ~
-  username: june-choe
+  username: june_choe
   photo: /assets/img/2022Conf/_talks/22100_june-choe.jpg
   bio: |+
     June is a second year Ph.D. student in linguistics at the University

--- a/sessions/advanced-r/cracking-open-ggplot-internals-ggtrace.md
+++ b/sessions/advanced-r/cracking-open-ggplot-internals-ggtrace.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/yjunechoe/ggtrace
     linkedin: ~
     affiliation: ~
-  slug: june-choe
+  username: june-choe
   photo: /assets/img/2022Conf/_talks/22100_june-choe.jpg
   bio: |+
     June is a second year Ph.D. student in linguistics at the University

--- a/sessions/advanced-r/introduction-to-r7.md
+++ b/sessions/advanced-r/introduction-to-r7.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/hadley
     linkedin: ~
     affiliation: https://rstudio.com
-  username: hadley-wickham
+  username: hadley_wickham
   photo: /assets/img/2022Conf/_talks/22110_hadley-wickham.jpg
   bio: |+
     Hadley is Chief Scientist at RStudio, winner of the 2019 COPSS award,

--- a/sessions/advanced-r/introduction-to-r7.md
+++ b/sessions/advanced-r/introduction-to-r7.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/hadley
     linkedin: ~
     affiliation: https://rstudio.com
-  slug: hadley-wickham
+  username: hadley-wickham
   photo: /assets/img/2022Conf/_talks/22110_hadley-wickham.jpg
   bio: |+
     Hadley is Chief Scientist at RStudio, winner of the 2019 COPSS award,

--- a/sessions/advanced-r/summarizing-projects-to-setting-tags.md
+++ b/sessions/advanced-r/summarizing-projects-to-setting-tags.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/brshallo
     linkedin: https://www.linkedin.com/in/bryanshalloway
     affiliation: https://www.netapp.com/
-  slug: bryan-shalloway
+  username: bryan-shalloway
   photo: /assets/img/2022Conf/_talks/22103_bryan-shalloway.jpg
   bio: |+
     Bryan is a Data Scientist at NetApp where he has worked on a

--- a/sessions/advanced-r/summarizing-projects-to-setting-tags.md
+++ b/sessions/advanced-r/summarizing-projects-to-setting-tags.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/brshallo
     linkedin: https://www.linkedin.com/in/bryanshalloway
     affiliation: https://www.netapp.com/
-  username: bryan-shalloway
+  username: bryan_shalloway
   photo: /assets/img/2022Conf/_talks/22103_bryan-shalloway.jpg
   bio: |+
     Bryan is a Data Scientist at NetApp where he has worked on a

--- a/sessions/big-shiny-apps/introducing-rhino-shiny-application-framework.md
+++ b/sessions/big-shiny-apps/introducing-rhino-shiny-application-framework.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/kamilzyla
     linkedin: https://www.linkedin.com/in/kamil-zyla/
     affiliation: ~
-  slug: kamil-zyla
+  username: kamil-zyla
   photo: /assets/img/2022Conf/_talks/22080_kamil-zyla.jpg
   bio: |+
     Kamil is a Full Stack Engineer at Appsilon and a core developer of

--- a/sessions/big-shiny-apps/introducing-rhino-shiny-application-framework.md
+++ b/sessions/big-shiny-apps/introducing-rhino-shiny-application-framework.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/kamilzyla
     linkedin: https://www.linkedin.com/in/kamil-zyla/
     affiliation: ~
-  username: kamil-zyla
+  username: kamil_zyla
   photo: /assets/img/2022Conf/_talks/22080_kamil-zyla.jpg
   bio: |+
     Kamil is a Full Stack Engineer at Appsilon and a core developer of

--- a/sessions/big-shiny-apps/robust-framework-for-automated-shiny.md
+++ b/sessions/big-shiny-apps/robust-framework-for-automated-shiny.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/sydeaka
     linkedin: https://www.linkedin.com/in/sydeakawatson/
     affiliation: https://www.lilly.com/
-  slug: sydeaka-watson
+  username: sydeaka-watson
   photo: /assets/img/2022Conf/_talks/22091_sydeaka-watson.jpeg
   bio: |+
     Dr. Sydeaka Watson earned a Ph.D. in Statistics from Baylor University

--- a/sessions/big-shiny-apps/robust-framework-for-automated-shiny.md
+++ b/sessions/big-shiny-apps/robust-framework-for-automated-shiny.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/sydeaka
     linkedin: https://www.linkedin.com/in/sydeakawatson/
     affiliation: https://www.lilly.com/
-  username: sydeaka-watson
+  username: sydeaka_watson
   photo: /assets/img/2022Conf/_talks/22091_sydeaka-watson.jpeg
   bio: |+
     Dr. Sydeaka Watson earned a Ph.D. in Statistics from Baylor University

--- a/sessions/big-shiny-apps/shinytest2-unit-testing-for-shiny.md
+++ b/sessions/big-shiny-apps/shinytest2-unit-testing-for-shiny.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/schloerke
     linkedin: https://www.linkedin.com/in/schloerke/
     affiliation: https://www.rstudio.com/
-  username: barret-schloerke
+  username: barret_schloerke
   photo: /assets/img/2022Conf/_talks/22115_barret-schloerke.png
   bio: |+
     `hello()`! Dr. Barret Schloerke is a Shiny Software Engineer

--- a/sessions/big-shiny-apps/shinytest2-unit-testing-for-shiny.md
+++ b/sessions/big-shiny-apps/shinytest2-unit-testing-for-shiny.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/schloerke
     linkedin: https://www.linkedin.com/in/schloerke/
     affiliation: https://www.rstudio.com/
-  slug: barret-schloerke
+  username: barret-schloerke
   photo: /assets/img/2022Conf/_talks/22115_barret-schloerke.png
   bio: |+
     `hello()`! Dr. Barret Schloerke is a Shiny Software Engineer

--- a/sessions/bringing-people-together/leveraging-r-based-ecosystem.md
+++ b/sessions/bringing-people-together/leveraging-r-based-ecosystem.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/achafetz
     linkedin: https://www.linkedin.com/in/aaron-chafetz
     affiliation: https://www.usaid.gov/
-  slug: aaron-chafetz
+  username: aaron-chafetz
   photo: /assets/img/2022Conf/_talks/22102_aaron-chafetz.jpg
   bio: |+
     Aaron Chafetz is a Senior Economist at the U.S. Agency for

--- a/sessions/bringing-people-together/leveraging-r-based-ecosystem.md
+++ b/sessions/bringing-people-together/leveraging-r-based-ecosystem.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/achafetz
     linkedin: https://www.linkedin.com/in/aaron-chafetz
     affiliation: https://www.usaid.gov/
-  username: aaron-chafetz
+  username: aaron_chafetz
   photo: /assets/img/2022Conf/_talks/22102_aaron-chafetz.jpg
   bio: |+
     Aaron Chafetz is a Senior Economist at the U.S. Agency for

--- a/sessions/bringing-people-together/model-migration-excel-to-r.md
+++ b/sessions/bringing-people-together/model-migration-excel-to-r.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/johnnyb1694
     linkedin: https://www.linkedin.com/in/johnnybreen/
     affiliation: https://www.tokiomarinekiln.com/
-  username: johnny-breen
+  username: johnny_breen
   photo: /assets/img/2022Conf/_talks/22024_johnny-breen.jpeg
   bio: |+
     Currently working as Portfolio Optimisation Lead at Tokio Marine Kiln,

--- a/sessions/bringing-people-together/model-migration-excel-to-r.md
+++ b/sessions/bringing-people-together/model-migration-excel-to-r.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/johnnyb1694
     linkedin: https://www.linkedin.com/in/johnnybreen/
     affiliation: https://www.tokiomarinekiln.com/
-  slug: johnny-breen
+  username: johnny-breen
   photo: /assets/img/2022Conf/_talks/22024_johnny-breen.jpeg
   bio: |+
     Currently working as Portfolio Optimisation Lead at Tokio Marine Kiln,

--- a/sessions/bringing-people-together/save-ocean-of-time-streamline.md
+++ b/sessions/bringing-people-together/save-ocean-of-time-streamline.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/dempsey-CMAR
     linkedin: https://www.linkedin.com/in/danielledempsey/
     affiliation: https://cmar.ca/
-  username: danielle-dempsey
+  username: danielle_dempsey
   photo: /assets/img/2022Conf/_talks/22146_danielle-dempsey.jpg
   bio: |+
     Danielle Dempsey is a Research Scientist and resident “R nerd” at the

--- a/sessions/bringing-people-together/save-ocean-of-time-streamline.md
+++ b/sessions/bringing-people-together/save-ocean-of-time-streamline.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/dempsey-CMAR
     linkedin: https://www.linkedin.com/in/danielledempsey/
     affiliation: https://cmar.ca/
-  slug: danielle-dempsey
+  username: danielle-dempsey
   photo: /assets/img/2022Conf/_talks/22146_danielle-dempsey.jpg
   bio: |+
     Danielle Dempsey is a Research Scientist and resident “R nerd” at the

--- a/sessions/bringing-people-together/tidy-transit-real-life-data.md
+++ b/sessions/bringing-people-together/tidy-transit-real-life-data.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/hunterowens
     linkedin: ~
     affiliation: calitp.org
-  username: hunter-owens
+  username: hunter_owens
   photo: /assets/img/2022Conf/_talks/22059_hunter-owens.png
   bio: |+
     Hunter Owens does data science in the public interest. Current at

--- a/sessions/bringing-people-together/tidy-transit-real-life-data.md
+++ b/sessions/bringing-people-together/tidy-transit-real-life-data.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/hunterowens
     linkedin: ~
     affiliation: calitp.org
-  slug: hunter-owens
+  username: hunter-owens
   photo: /assets/img/2022Conf/_talks/22059_hunter-owens.png
   bio: |+
     Hunter Owens does data science in the public interest. Current at

--- a/sessions/business-intelligence/building-client-portal-app.md
+++ b/sessions/business-intelligence/building-client-portal-app.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/thomas-wouters/
     affiliation: https://www.axi.be/nl
-  slug: thomas-wouters
+  username: thomas-wouters
   photo: /assets/img/2022Conf/_talks/22053_thomas-wouters.jpg
   bio: |+
     Thomas Wouters is a young man who is recently graduated in Applied
@@ -39,7 +39,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/joran-de-wilde-0b952b174/
     affiliation: https://www.axi.be
-  slug: joran-de-wilde
+  username: joran-de-wilde
   photo: /assets/img/2022Conf/_talks/22053_joran-de-wilde.png
   bio: |+
     Joran is a 24 year old man who recently graduated as Master of ICT

--- a/sessions/business-intelligence/building-client-portal-app.md
+++ b/sessions/business-intelligence/building-client-portal-app.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/thomas-wouters/
     affiliation: https://www.axi.be/nl
-  username: thomas-wouters
+  username: thomas_wouters
   photo: /assets/img/2022Conf/_talks/22053_thomas-wouters.jpg
   bio: |+
     Thomas Wouters is a young man who is recently graduated in Applied
@@ -39,7 +39,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/joran-de-wilde-0b952b174/
     affiliation: https://www.axi.be
-  username: joran-de-wilde
+  username: joran_de_wilde
   photo: /assets/img/2022Conf/_talks/22053_joran-de-wilde.png
   bio: |+
     Joran is a 24 year old man who recently graduated as Master of ICT

--- a/sessions/business-intelligence/r-python-tableau-love-triangle.md
+++ b/sessions/business-intelligence/r-python-tableau-love-triangle.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/blairj09
     linkedin: https://www.linkedin.com/in/blairjm/
     affiliation: https://www.rstudio.com/
-  username: james-blair
+  username: james_blair
   photo: /assets/img/2022Conf/_talks/22042_james-blair.jpg
   bio: |+
     James is a Product Manager for Cloud Integrations at RStudio, where

--- a/sessions/business-intelligence/r-python-tableau-love-triangle.md
+++ b/sessions/business-intelligence/r-python-tableau-love-triangle.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/blairj09
     linkedin: https://www.linkedin.com/in/blairjm/
     affiliation: https://www.rstudio.com/
-  slug: james-blair
+  username: james-blair
   photo: /assets/img/2022Conf/_talks/22042_james-blair.jpg
   bio: |+
     James is a Product Manager for Cloud Integrations at RStudio, where

--- a/sessions/business-intelligence/tidyverse-power-bi-match-made.md
+++ b/sessions/business-intelligence/tidyverse-power-bi-match-made.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/mrdatageek/
     affiliation: ~
-  slug: ryan-e-wade
+  username: ryan-e-wade
   photo: /assets/img/2022Conf/_talks/22013_ryan-e-wade.jpg
   bio: |+
     Ryan is a data and analytics solutions architect. He can present

--- a/sessions/business-intelligence/tidyverse-power-bi-match-made.md
+++ b/sessions/business-intelligence/tidyverse-power-bi-match-made.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/mrdatageek/
     affiliation: ~
-  username: ryan-e-wade
+  username: ryan_e_wade
   photo: /assets/img/2022Conf/_talks/22013_ryan-e-wade.jpg
   bio: |+
     Ryan is a data and analytics solutions architect. He can present

--- a/sessions/communities-of-practice/building-accessible-lessons-r-friends.md
+++ b/sessions/communities-of-practice/building-accessible-lessons-r-friends.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/zkamvar
     linkedin: https://linkedin.com/in/zkamvar
     affiliation: https://carpentries.org
-  username: zhian-n-kamvar
+  username: zhian_n_kamvar
   photo: /assets/img/2022Conf/_talks/22120_zhian-n-kamvar.png
   bio: |+
     Zhian is the Lesson Infrastructure Technology Developer for [The

--- a/sessions/communities-of-practice/building-accessible-lessons-r-friends.md
+++ b/sessions/communities-of-practice/building-accessible-lessons-r-friends.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/zkamvar
     linkedin: https://linkedin.com/in/zkamvar
     affiliation: https://carpentries.org
-  slug: zhian-n-kamvar
+  username: zhian-n-kamvar
   photo: /assets/img/2022Conf/_talks/22120_zhian-n-kamvar.png
   bio: |+
     Zhian is the Lesson Infrastructure Technology Developer for [The

--- a/sessions/communities-of-practice/everything-learned-community-building-learned.md
+++ b/sessions/communities-of-practice/everything-learned-community-building-learned.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://linkedin.com/in/rachaeldempsey
     affiliation: https://rstudio.com/champion
-  username: rachael-dempsey
+  username: rachael_dempsey
   photo: /assets/img/2022Conf/_talks/22123_rachael-dempsey.png
   bio: |+
     Rachael is a community leader at RStudio with a passion for customer

--- a/sessions/communities-of-practice/everything-learned-community-building-learned.md
+++ b/sessions/communities-of-practice/everything-learned-community-building-learned.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://linkedin.com/in/rachaeldempsey
     affiliation: https://rstudio.com/champion
-  slug: rachael-dempsey
+  username: rachael-dempsey
   photo: /assets/img/2022Conf/_talks/22123_rachael-dempsey.png
   bio: |+
     Rachael is a community leader at RStudio with a passion for customer

--- a/sessions/communities-of-practice/journey-to-data-science-tools.md
+++ b/sessions/communities-of-practice/journey-to-data-science-tools.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/IleanaF
     linkedin: https://www.linkedin.com/in/ileana-fenwick-0238ba132/
     affiliation: https://nye.unc.edu/
-  slug: ileana-fenwick
+  username: ileana-fenwick
   photo: /assets/img/2022Conf/_talks/22083_ileana-fenwick.jpg
   bio: |+
     Ileana Fenwick is an open science advocate and Marine Sciences Ph.D.

--- a/sessions/communities-of-practice/journey-to-data-science-tools.md
+++ b/sessions/communities-of-practice/journey-to-data-science-tools.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/IleanaF
     linkedin: https://www.linkedin.com/in/ileana-fenwick-0238ba132/
     affiliation: https://nye.unc.edu/
-  username: ileana-fenwick
+  username: ileana_fenwick
   photo: /assets/img/2022Conf/_talks/22083_ileana-fenwick.jpg
   bio: |+
     Ileana Fenwick is an open science advocate and Marine Sciences Ph.D.

--- a/sessions/communities-of-practice/r-kagglers-intersection-of-data.md
+++ b/sessions/communities-of-practice/r-kagglers-intersection-of-data.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/martin-henze/
     affiliation: https://www.yipitdata.com/
-  slug: martin-henze
+  username: martin-henze
   photo: /assets/img/2022Conf/_talks/22208_martin-henze.jpg
   bio: |+
     Data Scientist @ YipitData | Kaggle Grandmaster | PhD Astrophysicist

--- a/sessions/communities-of-practice/r-kagglers-intersection-of-data.md
+++ b/sessions/communities-of-practice/r-kagglers-intersection-of-data.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/martin-henze/
     affiliation: https://www.yipitdata.com/
-  username: martin-henze
+  username: martin_henze
   photo: /assets/img/2022Conf/_talks/22208_martin-henze.jpg
   bio: |+
     Data Scientist @ YipitData | Kaggle Grandmaster | PhD Astrophysicist

--- a/sessions/data-quality/bad-data-what-to-do.md
+++ b/sessions/data-quality/bad-data-what-to-do.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/jimtheflash
     linkedin: https://www.linkedin.com/in/jimkloet/
     affiliation: ~
-  slug: jim-kloet
+  username: jim-kloet
   photo: /assets/img/2022Conf/_talks/22153_jim-kloet.png
   bio: |+
     Jim Kloet (_Kloet_ rhymes with _flute_) is a data professional in

--- a/sessions/data-quality/bad-data-what-to-do.md
+++ b/sessions/data-quality/bad-data-what-to-do.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/jimtheflash
     linkedin: https://www.linkedin.com/in/jimkloet/
     affiliation: ~
-  username: jim-kloet
+  username: jim_kloet
   photo: /assets/img/2022Conf/_talks/22153_jim-kloet.png
   bio: |+
     Jim Kloet (_Kloet_ rhymes with _flute_) is a data professional in

--- a/sessions/data-quality/levelling-github-to-automate-powerful.md
+++ b/sessions/data-quality/levelling-github-to-automate-powerful.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/tanho63
     linkedin: ~
     affiliation: ~
-  slug: tan-ho
+  username: tan-ho
   photo: /assets/img/2022Conf/_talks/22168_tan-ho.jpg
   bio: |-
     I'm a data enthusiast who loves R 🚀, Shiny ✨, fantasy football 🏈

--- a/sessions/data-quality/levelling-github-to-automate-powerful.md
+++ b/sessions/data-quality/levelling-github-to-automate-powerful.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/tanho63
     linkedin: ~
     affiliation: ~
-  username: tan-ho
+  username: tan_ho
   photo: /assets/img/2022Conf/_talks/22168_tan-ho.jpg
   bio: |-
     I'm a data enthusiast who loves R 🚀, Shiny ✨, fantasy football 🏈

--- a/sessions/data-quality/making-data-pipelines-in-r.md
+++ b/sessions/data-quality/making-data-pipelines-in-r.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/Meghansaha
     linkedin: https://www.linkedin.com/in/meghan-harris/
     affiliation: https://medicine.buffalo.edu/departments/family-medicine/research.html
-  slug: meghan-s-harris
+  username: meghan-s-harris
   photo: /assets/img/2022Conf/_talks/22005_meghan-s-harris.jpg
   bio: |+
     Meghan Harris is a self-taught R user that is a data integration

--- a/sessions/data-quality/making-data-pipelines-in-r.md
+++ b/sessions/data-quality/making-data-pipelines-in-r.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/Meghansaha
     linkedin: https://www.linkedin.com/in/meghan-harris/
     affiliation: https://medicine.buffalo.edu/departments/family-medicine/research.html
-  username: meghan-s-harris
+  username: meghan_s_harris
   photo: /assets/img/2022Conf/_talks/22005_meghan-s-harris.jpg
   bio: |+
     Meghan Harris is a self-taught R user that is a data integration

--- a/sessions/data-quality/r-markdown-rstudio-connect-r.md
+++ b/sessions/data-quality/r-markdown-rstudio-connect-r.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: ~
-  slug: kolbi-parrish
+  username: kolbi-parrish
   photo: /assets/img/2022Conf/_talks/22221_kolbi-parrish.jpg
   bio: |+
     Kolbi Parrish is an Informatics Specialist working at the California
@@ -39,7 +39,7 @@ speakers:
     github: https://github.com/PoppinHandy
     linkedin: https://www.linkedin.com/in/handy94/
     affiliation: ~
-  slug: andy-pham
+  username: andy-pham
   photo: /assets/img/2022Conf/_talks/22221_andy-pham.jpg
   bio: |+
     Andy is a clinical informatics specialist working at the California

--- a/sessions/data-quality/r-markdown-rstudio-connect-r.md
+++ b/sessions/data-quality/r-markdown-rstudio-connect-r.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: ~
-  username: kolbi-parrish
+  username: kolbi_parrish
   photo: /assets/img/2022Conf/_talks/22221_kolbi-parrish.jpg
   bio: |+
     Kolbi Parrish is an Informatics Specialist working at the California
@@ -39,7 +39,7 @@ speakers:
     github: https://github.com/PoppinHandy
     linkedin: https://www.linkedin.com/in/handy94/
     affiliation: ~
-  username: andy-pham
+  username: andy_pham
   photo: /assets/img/2022Conf/_talks/22221_andy-pham.jpg
   bio: |+
     Andy is a clinical informatics specialist working at the California

--- a/sessions/data-science-in-production/r-shiny-conception-to-cloud.md
+++ b/sessions/data-science-in-production/r-shiny-conception-to-cloud.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/ivonne-carrillo-dominguez/
     affiliation: https://www.bixal.com/about/ivonne-carrillo-dominguez/
-  slug: ivonne-carrillo-dominguez
+  username: ivonne-carrillo-dominguez
   photo: /assets/img/2022Conf/_talks/22136_ivonne-carrillo-dominguez.jpeg
   bio: |+
     Ivonne is a data engineer on the Data Science team at Bixal where

--- a/sessions/data-science-in-production/r-shiny-conception-to-cloud.md
+++ b/sessions/data-science-in-production/r-shiny-conception-to-cloud.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/ivonne-carrillo-dominguez/
     affiliation: https://www.bixal.com/about/ivonne-carrillo-dominguez/
-  username: ivonne-carrillo-dominguez
+  username: ivonne_carrillo_dominguez
   photo: /assets/img/2022Conf/_talks/22136_ivonne-carrillo-dominguez.jpeg
   bio: |+
     Ivonne is a data engineer on the Data Science team at Bixal where

--- a/sessions/data-science-in-production/rapidly-building-secure-customer-facing.md
+++ b/sessions/data-science-in-production/rapidly-building-secure-customer-facing.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/benjybraun/
     affiliation: https://www.202group.com
-  slug: benjamin-braun
+  username: benjamin-braun
   photo: /assets/img/2022Conf/_talks/22018_benjamin-braun.jpg
   bio: |+
     I am a mission-driven problem solver with expertise in bringing data

--- a/sessions/data-science-in-production/rapidly-building-secure-customer-facing.md
+++ b/sessions/data-science-in-production/rapidly-building-secure-customer-facing.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/benjybraun/
     affiliation: https://www.202group.com
-  username: benjamin-braun
+  username: benjamin_braun
   photo: /assets/img/2022Conf/_talks/22018_benjamin-braun.jpg
   bio: |+
     I am a mission-driven problem solver with expertise in bringing data

--- a/sessions/data-science-in-production/remote-content-execution-rstudio-connect.md
+++ b/sessions/data-science-in-production/remote-content-execution-rstudio-connect.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/kellobri
     linkedin: https://www.linkedin.com/in/kellyobriant/
     affiliation: ~
-  slug: kelly-obriant
+  username: kelly-obriant
   photo: /assets/img/2022Conf/_talks/22010_kelly-obriant.jpg
   bio: |+
     Kelly O'Briant is the Product Manager for RStudio Connect.

--- a/sessions/data-science-in-production/remote-content-execution-rstudio-connect.md
+++ b/sessions/data-science-in-production/remote-content-execution-rstudio-connect.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/kellobri
     linkedin: https://www.linkedin.com/in/kellyobriant/
     affiliation: ~
-  username: kelly-obriant
+  username: kelly_obriant
   photo: /assets/img/2022Conf/_talks/22010_kelly-obriant.jpg
   bio: |+
     Kelly O'Briant is the Product Manager for RStudio Connect.

--- a/sessions/data-science-in-production/robust-r-deployments-building-pipeline.md
+++ b/sessions/data-science-in-production/robust-r-deployments-building-pipeline.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/davemaguire
     linkedin: https://www.linkedin.com/in/david-maguire-30636956/
     affiliation: https://www.dv01.co/offerings/tape-cracker/
-  username: david-maguire
+  username: david_maguire
   photo: /assets/img/2022Conf/_talks/22198_david-maguire.jpg
   bio: |+
     A physical scientist by training, David leverages the scientific

--- a/sessions/data-science-in-production/robust-r-deployments-building-pipeline.md
+++ b/sessions/data-science-in-production/robust-r-deployments-building-pipeline.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/davemaguire
     linkedin: https://www.linkedin.com/in/david-maguire-30636956/
     affiliation: https://www.dv01.co/offerings/tape-cracker/
-  slug: david-maguire
+  username: david-maguire
   photo: /assets/img/2022Conf/_talks/22198_david-maguire.jpg
   bio: |+
     A physical scientist by training, David leverages the scientific

--- a/sessions/databases/dbcooper-turn-database-r-python.md
+++ b/sessions/databases/dbcooper-turn-database-r-python.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/dgrtwo
     linkedin: https://www.linkedin.com/in/david-robinson-3584642a
     affiliation: https://heap.io/
-  slug: david-robinson
+  username: david-robinson
   photo: /assets/img/2022Conf/_talks/22214_david-robinson.jpg
   bio: |+
     David Robinson is Director of Data Science at Heap Analytics, where

--- a/sessions/databases/dbcooper-turn-database-r-python.md
+++ b/sessions/databases/dbcooper-turn-database-r-python.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/dgrtwo
     linkedin: https://www.linkedin.com/in/david-robinson-3584642a
     affiliation: https://heap.io/
-  username: david_robinson
+  username: dgrtwo
   photo: /assets/img/2022Conf/_talks/22214_david-robinson.jpg
   bio: |+
     David Robinson is Director of Data Science at Heap Analytics, where

--- a/sessions/databases/dbcooper-turn-database-r-python.md
+++ b/sessions/databases/dbcooper-turn-database-r-python.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/dgrtwo
     linkedin: https://www.linkedin.com/in/david-robinson-3584642a
     affiliation: https://heap.io/
-  username: david-robinson
+  username: david_robinson
   photo: /assets/img/2022Conf/_talks/22214_david-robinson.jpg
   bio: |+
     David Robinson is Director of Data Science at Heap Analytics, where

--- a/sessions/databases/dm-analyze-build-deploy-relational.md
+++ b/sessions/databases/dm-analyze-build-deploy-relational.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/krlmlr/
     linkedin: https://www.linkedin.com/in/kirill-m%C3%BCller/
     affiliation: https://cynkra.com
-  slug: kirill-muller
+  username: kirill-muller
   photo: /assets/img/2022Conf/_talks/22187_kirill-muller.jpeg
   bio: |+
     Kirill has been working on the boundary between data and computer

--- a/sessions/databases/dm-analyze-build-deploy-relational.md
+++ b/sessions/databases/dm-analyze-build-deploy-relational.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/krlmlr/
     linkedin: https://www.linkedin.com/in/kirill-m%C3%BCller/
     affiliation: https://cynkra.com
-  username: kirill-muller
+  username: kirill_muller
   photo: /assets/img/2022Conf/_talks/22187_kirill-muller.jpeg
   bio: |+
     Kirill has been working on the boundary between data and computer

--- a/sessions/databases/time-to-optimize-poorly-optimized.md
+++ b/sessions/databases/time-to-optimize-poorly-optimized.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/bhadi26
     linkedin: https://www.linkedin.com/in/rebeccahadi/
     affiliation: https://lynhealth.io
-  slug: rebecca-hadi
+  username: rebecca-hadi
   photo: /assets/img/2022Conf/_talks/22007_rebecca-hadi.jpg
   bio: |+
     Rebecca Hadi is the Head of Data Science at Lyn Health. She holds a

--- a/sessions/databases/time-to-optimize-poorly-optimized.md
+++ b/sessions/databases/time-to-optimize-poorly-optimized.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/bhadi26
     linkedin: https://www.linkedin.com/in/rebeccahadi/
     affiliation: https://lynhealth.io
-  username: rebecca-hadi
+  username: rebecca_hadi
   photo: /assets/img/2022Conf/_talks/22007_rebecca-hadi.jpg
   bio: |+
     Rebecca Hadi is the Head of Data Science at Lyn Health. She holds a

--- a/sessions/delightful-uses/building-ggplot2-rollercoaster-creating-amazing.md
+++ b/sessions/delightful-uses/building-ggplot2-rollercoaster-creating-amazing.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/tylermorganwall
     linkedin: https://www.linkedin.com/in/tyler-morgan-wall-88227015/
     affiliation: https://www.ida.org
-  slug: tyler-morgan-wall
+  username: tyler-morgan-wall
   photo: /assets/img/2022Conf/_talks/22131_tyler-morgan-wall.jpg
   bio: |+
     Dr. Tyler Morgan-Wall is the developer of the **rayverse**:

--- a/sessions/delightful-uses/building-ggplot2-rollercoaster-creating-amazing.md
+++ b/sessions/delightful-uses/building-ggplot2-rollercoaster-creating-amazing.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/tylermorganwall
     linkedin: https://www.linkedin.com/in/tyler-morgan-wall-88227015/
     affiliation: https://www.ida.org
-  username: tyler-morgan-wall
+  username: tyler_morgan_wall
   photo: /assets/img/2022Conf/_talks/22131_tyler-morgan-wall.jpg
   bio: |+
     Dr. Tyler Morgan-Wall is the developer of the **rayverse**:

--- a/sessions/delightful-uses/polygons-of-another-world-realtime.md
+++ b/sessions/delightful-uses/polygons-of-another-world-realtime.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/coolbutuseless
     linkedin: https://www.linkedin.com/in/michael-cheng-8782632b
     affiliation: ~
-  username: mike-cheng
+  username: mike_cheng
   photo: /assets/img/2022Conf/_talks/22135_mike-cheng.png
   bio: |+
     TBD. Will write this when I get the chance

--- a/sessions/delightful-uses/polygons-of-another-world-realtime.md
+++ b/sessions/delightful-uses/polygons-of-another-world-realtime.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/coolbutuseless
     linkedin: https://www.linkedin.com/in/michael-cheng-8782632b
     affiliation: ~
-  slug: mike-cheng
+  username: mike-cheng
   photo: /assets/img/2022Conf/_talks/22135_mike-cheng.png
   bio: |+
     TBD. Will write this when I get the chance

--- a/sessions/delightful-uses/quilting-in-r-becoming-creative.md
+++ b/sessions/delightful-uses/quilting-in-r-becoming-creative.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/awalsh17
     linkedin: https://www.linkedin.com/in/alice-walsh/
     affiliation: ~
-  username: alice-walsh-phd
+  username: alice_walsh_phd
   photo: /assets/img/2022Conf/_talks/22062_alice-walsh-phd.jpg
   bio: |+
     Alice is a computational biologist who applies data science

--- a/sessions/delightful-uses/quilting-in-r-becoming-creative.md
+++ b/sessions/delightful-uses/quilting-in-r-becoming-creative.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/awalsh17
     linkedin: https://www.linkedin.com/in/alice-walsh/
     affiliation: ~
-  slug: alice-walsh-phd
+  username: alice-walsh-phd
   photo: /assets/img/2022Conf/_talks/22062_alice-walsh-phd.jpg
   bio: |+
     Alice is a computational biologist who applies data science

--- a/sessions/keynote/applied-machine-learning.md
+++ b/sessions/keynote/applied-machine-learning.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/juliasilge
     linkedin: ~
     affiliation: ~
-  slug: julia-silge
+  username: julia-silge
   photo: /assets/img/2022Conf/_talks/22301_julia-silge.jpeg
   bio: |+
     NA
@@ -34,7 +34,7 @@ speakers:
     github: https://github.com/topepo
     linkedin: ~
     affiliation: ~
-  slug: max-kuhn
+  username: max-kuhn
   photo: /assets/img/2022Conf/_talks/22301_max-kuhn.jpeg
   bio: |+
     NA

--- a/sessions/keynote/applied-machine-learning.md
+++ b/sessions/keynote/applied-machine-learning.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/juliasilge
     linkedin: ~
     affiliation: ~
-  username: julia-silge
+  username: julia_silge
   photo: /assets/img/2022Conf/_talks/22301_julia-silge.jpeg
   bio: |+
     NA
@@ -34,7 +34,7 @@ speakers:
     github: https://github.com/topepo
     linkedin: ~
     affiliation: ~
-  username: max-kuhn
+  username: max_kuhn
   photo: /assets/img/2022Conf/_talks/22301_max-kuhn.jpeg
   bio: |+
     NA

--- a/sessions/keynote/collaborate-with-quarto.md
+++ b/sessions/keynote/collaborate-with-quarto.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/mine-cetinkaya-rundel
     linkedin: ~
     affiliation: ~
-  username: mine-çetinkaya-rundel
+  username: mine_çetinkaya_rundel
   photo: /assets/img/2022Conf/_talks/22303_mine-cetinkaya-rundel.jpg
   bio: |+
     Mine Çetinkaya-Rundel is Professor of the Practice at Duke University and
@@ -50,7 +50,7 @@ speakers:
     github: https://github.com/jules32
     linkedin: ~
     affiliation: ~
-  username: julia-stewart-lowndes
+  username: julia_stewart_lowndes
   photo: /assets/img/2022Conf/_talks/22303_julia-stewart-lowndes.jpeg
   bio: |+
     [Julia Stewart Lowndes](http://jules32.github.io/), PhD founded

--- a/sessions/keynote/collaborate-with-quarto.md
+++ b/sessions/keynote/collaborate-with-quarto.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/mine-cetinkaya-rundel
     linkedin: ~
     affiliation: ~
-  slug: mine-çetinkaya-rundel
+  username: mine-çetinkaya-rundel
   photo: /assets/img/2022Conf/_talks/22303_mine-cetinkaya-rundel.jpg
   bio: |+
     Mine Çetinkaya-Rundel is Professor of the Practice at Duke University and
@@ -50,7 +50,7 @@ speakers:
     github: https://github.com/jules32
     linkedin: ~
     affiliation: ~
-  slug: julia-stewart-lowndes
+  username: julia-stewart-lowndes
   photo: /assets/img/2022Conf/_talks/22303_julia-stewart-lowndes.jpeg
   bio: |+
     [Julia Stewart Lowndes](http://jules32.github.io/), PhD founded

--- a/sessions/keynote/collaborate-with-quarto.md
+++ b/sessions/keynote/collaborate-with-quarto.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/mine-cetinkaya-rundel
     linkedin: ~
     affiliation: ~
-  username: mine_çetinkaya_rundel
+  username: mine_cetinkaya_rundel
   photo: /assets/img/2022Conf/_talks/22303_mine-cetinkaya-rundel.jpg
   bio: |+
     Mine Çetinkaya-Rundel is Professor of the Practice at Duke University and

--- a/sessions/keynote/data-science-training.md
+++ b/sessions/keynote/data-science-training.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/jtleek
     linkedin: ~
     affiliation: ~
-  slug: jeff-leek
+  username: jeff-leek
   photo: /assets/img/2022Conf/_talks/22304_jeff-leek.jpeg
   bio: |+
     NA

--- a/sessions/keynote/data-science-training.md
+++ b/sessions/keynote/data-science-training.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/jtleek
     linkedin: ~
     affiliation: ~
-  username: jeff-leek
+  username: jeff_leek
   photo: /assets/img/2022Conf/_talks/22304_jeff-leek.jpeg
   bio: |+
     NA

--- a/sessions/keynote/past-future-shiny.md
+++ b/sessions/keynote/past-future-shiny.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/jcheng5
     linkedin: ~
     affiliation: ~
-  username: joe-cheng
+  username: joe_cheng
   photo: /assets/img/2022Conf/_talks/22302_joe-cheng.jpeg
   bio: |+
     NA

--- a/sessions/keynote/past-future-shiny.md
+++ b/sessions/keynote/past-future-shiny.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/jcheng5
     linkedin: ~
     affiliation: ~
-  slug: joe-cheng
+  username: joe-cheng
   photo: /assets/img/2022Conf/_talks/22302_joe-cheng.jpeg
   bio: |+
     NA

--- a/sessions/lightning-talks/accelerating-geospatial-computing-using-apache.md
+++ b/sessions/lightning-talks/accelerating-geospatial-computing-using-apache.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/paleolimbot/
     linkedin: https://www.linkedin.com/in/deweydunnington/
     affiliation: https://voltrondata.com/
-  username: dewey-dunnington
+  username: dewey_dunnington
   photo: /assets/img/2022Conf/_talks/22036_dewey-dunnington.jpg
   bio: |+
     Dewey Dunnington (Ph.D., P.Geo.) is an environmental researcher,

--- a/sessions/lightning-talks/accelerating-geospatial-computing-using-apache.md
+++ b/sessions/lightning-talks/accelerating-geospatial-computing-using-apache.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/paleolimbot/
     linkedin: https://www.linkedin.com/in/deweydunnington/
     affiliation: https://voltrondata.com/
-  slug: dewey-dunnington
+  username: dewey-dunnington
   photo: /assets/img/2022Conf/_talks/22036_dewey-dunnington.jpg
   bio: |+
     Dewey Dunnington (Ph.D., P.Geo.) is an environmental researcher,

--- a/sessions/lightning-talks/comparing-package-versions-diffify.md
+++ b/sessions/lightning-talks/comparing-package-versions-diffify.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/csgillespie/
     linkedin: https://www.linkedin.com/in/colin-gillespie-25028332/
     affiliation: https://jumpingrivers.com/
-  username: colin-gillespie
+  username: colin_gillespie
   photo: /assets/img/2022Conf/_talks/22196_colin-gillespie.jpg
   bio: |+
     Colin has been using R since 1999. He's the author of a number of R

--- a/sessions/lightning-talks/comparing-package-versions-diffify.md
+++ b/sessions/lightning-talks/comparing-package-versions-diffify.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/csgillespie/
     linkedin: https://www.linkedin.com/in/colin-gillespie-25028332/
     affiliation: https://jumpingrivers.com/
-  slug: colin-gillespie
+  username: colin-gillespie
   photo: /assets/img/2022Conf/_talks/22196_colin-gillespie.jpg
   bio: |+
     Colin has been using R since 1999. He's the author of a number of R

--- a/sessions/lightning-talks/comparing-package-versions-diffify.md
+++ b/sessions/lightning-talks/comparing-package-versions-diffify.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/csgillespie/
     linkedin: https://www.linkedin.com/in/colin-gillespie-25028332/
     affiliation: https://jumpingrivers.com/
-  username: colin_gillespie
+  username: csgillespie
   photo: /assets/img/2022Conf/_talks/22196_colin-gillespie.jpg
   bio: |+
     Colin has been using R since 1999. He's the author of a number of R

--- a/sessions/lightning-talks/exploratory-spatial-data-analysis.md
+++ b/sessions/lightning-talks/exploratory-spatial-data-analysis.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/josiahparry
     linkedin: https://www.linkedin.com/in/josiahparry/
     affiliation: https://www.npd.com/
-  slug: josiah-parry
+  username: josiah-parry
   photo: /assets/img/2022Conf/_talks/22014_josiah-parry.jpg
   bio: |+
     Josiah Parry is a Research Analyst in the Research Science division

--- a/sessions/lightning-talks/exploratory-spatial-data-analysis.md
+++ b/sessions/lightning-talks/exploratory-spatial-data-analysis.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/josiahparry
     linkedin: https://www.linkedin.com/in/josiahparry/
     affiliation: https://www.npd.com/
-  username: josiah-parry
+  username: josiah_parry
   photo: /assets/img/2022Conf/_talks/22014_josiah-parry.jpg
   bio: |+
     Josiah Parry is a Research Analyst in the Research Science division

--- a/sessions/lightning-talks/future-of-missing-data.md
+++ b/sessions/lightning-talks/future-of-missing-data.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/njtierney
     linkedin: https://www.linkedin.com/in/nj-tierney/
     affiliation: https://www.telethonkids.org.au/our-research/brain-and-behaviour/population-health-program/geospatial-health-and-development/
-  slug: nicholas-tierney
+  username: nicholas-tierney
   photo: /assets/img/2022Conf/_talks/22233_nicholas-tierney.jpeg
   bio: |+
     Nick Tierney has an honours degree in Psychology, and a PhD in

--- a/sessions/lightning-talks/future-of-missing-data.md
+++ b/sessions/lightning-talks/future-of-missing-data.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/njtierney
     linkedin: https://www.linkedin.com/in/nj-tierney/
     affiliation: https://www.telethonkids.org.au/our-research/brain-and-behaviour/population-health-program/geospatial-health-and-development/
-  username: nicholas-tierney
+  username: nicholas_tierney
   photo: /assets/img/2022Conf/_talks/22233_nicholas-tierney.jpeg
   bio: |+
     Nick Tierney has an honours degree in Psychology, and a PhD in

--- a/sessions/lightning-talks/implications-of-r-syntax.md
+++ b/sessions/lightning-talks/implications-of-r-syntax.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/AmeliaMN
     linkedin: ~
     affiliation: ~
-  username: amelia-mcnamara
+  username: amelia_mcnamara
   photo: /assets/img/2022Conf/_talks/22195_amelia-mcnamara.jpg
   bio: |+
     Amelia McNamara is an assistant professor of statistics at the

--- a/sessions/lightning-talks/implications-of-r-syntax.md
+++ b/sessions/lightning-talks/implications-of-r-syntax.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/AmeliaMN
     linkedin: ~
     affiliation: ~
-  slug: amelia-mcnamara
+  username: amelia-mcnamara
   photo: /assets/img/2022Conf/_talks/22195_amelia-mcnamara.jpg
   bio: |+
     Amelia McNamara is an assistant professor of statistics at the

--- a/sessions/lightning-talks/its-about-time.md
+++ b/sessions/lightning-talks/its-about-time.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/DavisVaughan
     linkedin: ~
     affiliation: ~
-  username: davis-vaughan
+  username: davis_vaughan
   photo: /assets/img/2022Conf/_talks/22028_davis-vaughan.jpg
   bio: |+
     Davis is a software engineer at RStudio working on improving the

--- a/sessions/lightning-talks/its-about-time.md
+++ b/sessions/lightning-talks/its-about-time.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/DavisVaughan
     linkedin: ~
     affiliation: ~
-  slug: davis-vaughan
+  username: davis-vaughan
   photo: /assets/img/2022Conf/_talks/22028_davis-vaughan.jpg
   bio: |+
     Davis is a software engineer at RStudio working on improving the

--- a/sessions/lightning-talks/leafdown-interactive-multi-layer-maps.md
+++ b/sessions/lightning-talks/leafdown-interactive-multi-layer-maps.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/andreash0
     linkedin: https://www.linkedin.com/in/andreas-hofheinz-3b686913b/
     affiliation: ~
-  slug: andreas-hofheinz
+  username: andreas-hofheinz
   photo: /assets/img/2022Conf/_talks/22128_andreas-hofheinz.jpg
   bio: |+
     Andreas is a consultant at d-fine and maintainer of the leafdown R

--- a/sessions/lightning-talks/leafdown-interactive-multi-layer-maps.md
+++ b/sessions/lightning-talks/leafdown-interactive-multi-layer-maps.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/andreash0
     linkedin: https://www.linkedin.com/in/andreas-hofheinz-3b686913b/
     affiliation: ~
-  username: andreas-hofheinz
+  username: andreas_hofheinz
   photo: /assets/img/2022Conf/_talks/22128_andreas-hofheinz.jpg
   bio: |+
     Andreas is a consultant at d-fine and maintainer of the leafdown R
@@ -36,11 +36,11 @@ speakers:
 Please write abstract below. You may use simple markdown (links, code style, bold, italics)
 -->
 
-Interactive maps are indispensable tools for exploring spatial datasets 
-because of their real-world context and intuitiveness. For a comprehensive 
-understanding of the data, it is often necessary to switch between 
-several map layers (such as states and counties) and to analyze multiple 
-variables simultaneously - both of which are challenging. In this talk, 
-I will show how we can overcome these challenges using the 
-leafdown package, which allows us to create multi-layer maps embedded 
+Interactive maps are indispensable tools for exploring spatial datasets
+because of their real-world context and intuitiveness. For a comprehensive
+understanding of the data, it is often necessary to switch between
+several map layers (such as states and counties) and to analyze multiple
+variables simultaneously - both of which are challenging. In this talk,
+I will show how we can overcome these challenges using the
+leafdown package, which allows us to create multi-layer maps embedded
 in Shiny apps.

--- a/sessions/lightning-talks/let-mobile-shine-leveraging-css.md
+++ b/sessions/lightning-talks/let-mobile-shine-leveraging-css.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/Shelmith-Kariuki
     linkedin: https://www.linkedin.com/in/shelmith-kariuki-44351363/
     affiliation: ~
-  username: shelmith-nyagathiri-kariuki
+  username: shelmith_nyagathiri_kariuki
   photo: /assets/img/2022Conf/_talks/22035_shelmith-nyagathiri-kariuki.jpg
   bio: |+
     Shel Kariuki is a Data Analytics consultant based in Nairobi, Kenya.

--- a/sessions/lightning-talks/let-mobile-shine-leveraging-css.md
+++ b/sessions/lightning-talks/let-mobile-shine-leveraging-css.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/Shelmith-Kariuki
     linkedin: https://www.linkedin.com/in/shelmith-kariuki-44351363/
     affiliation: ~
-  slug: shelmith-nyagathiri-kariuki
+  username: shelmith-nyagathiri-kariuki
   photo: /assets/img/2022Conf/_talks/22035_shelmith-nyagathiri-kariuki.jpg
   bio: |+
     Shel Kariuki is a Data Analytics consultant based in Nairobi, Kenya.

--- a/sessions/lightning-talks/lets-start-beginning-bits.md
+++ b/sessions/lightning-talks/lets-start-beginning-bits.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/farach
     linkedin: https://www.linkedin.com/in/alex-farach/
     affiliation: https://www.accenture.com/us-en/services/us-federal-government/artificial-intelligence
-  username: alex-farach
+  username: alex_farach
   photo: /assets/img/2022Conf/_talks/22154_alex-farach.jpeg
   bio: |+
     Alex Farach is an Analytics Manager and Data Scientist in the Applied

--- a/sessions/lightning-talks/lets-start-beginning-bits.md
+++ b/sessions/lightning-talks/lets-start-beginning-bits.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/farach
     linkedin: https://www.linkedin.com/in/alex-farach/
     affiliation: https://www.accenture.com/us-en/services/us-federal-government/artificial-intelligence
-  slug: alex-farach
+  username: alex-farach
   photo: /assets/img/2022Conf/_talks/22154_alex-farach.jpeg
   bio: |+
     Alex Farach is an Analytics Manager and Data Scientist in the Applied

--- a/sessions/lightning-talks/making-awesome-automations-github-actions.md
+++ b/sessions/lightning-talks/making-awesome-automations-github-actions.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/beatrizmilz
     linkedin: https://www.linkedin.com/in/beatrizmilz/
     affiliation: https://curso-r.com/
-  username: beatriz-milz
+  username: beatriz_milz
   photo: /assets/img/2022Conf/_talks/22066_beatriz-milz.jpeg
   bio: |+
     [PhD Candidante in Environmental Science in the University of Sao

--- a/sessions/lightning-talks/making-awesome-automations-github-actions.md
+++ b/sessions/lightning-talks/making-awesome-automations-github-actions.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/beatrizmilz
     linkedin: https://www.linkedin.com/in/beatrizmilz/
     affiliation: https://curso-r.com/
-  slug: beatriz-milz
+  username: beatriz-milz
   photo: /assets/img/2022Conf/_talks/22066_beatriz-milz.jpeg
   bio: |+
     [PhD Candidante in Environmental Science in the University of Sao

--- a/sessions/lightning-talks/say-hello-to-multilingual-shiny.md
+++ b/sessions/lightning-talks/say-hello-to-multilingual-shiny.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/nrennie
     linkedin: https://www.linkedin.com/in/nicola-rennie-076511b3/
     affiliation: https://www.jumpingrivers.com/
-  slug: nicola-rennie
+  username: nicola-rennie
   photo: /assets/img/2022Conf/_talks/22141_nicola-rennie.jpg
   bio: |+
     Nicola Rennie is a statistician and data scientist, passionate about

--- a/sessions/lightning-talks/say-hello-to-multilingual-shiny.md
+++ b/sessions/lightning-talks/say-hello-to-multilingual-shiny.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/nrennie
     linkedin: https://www.linkedin.com/in/nicola-rennie-076511b3/
     affiliation: https://www.jumpingrivers.com/
-  username: nicola-rennie
+  username: nicola_rennie
   photo: /assets/img/2022Conf/_talks/22141_nicola-rennie.jpg
   bio: |+
     Nicola Rennie is a statistician and data scientist, passionate about
@@ -46,9 +46,9 @@ spoken languages.
 Using a bilingual English-Welsh shiny app we developed to present public health
 data as a case study, this talk will discuss:
 
-- how we built a multilingual shiny app; 
+- how we built a multilingual shiny app;
 - how translation affected design decisions;
-- how we overcame the main issues faced; 
+- how we overcame the main issues faced;
 - and most importantly, what we'd do differently next time.
 
 By the end of this talk, you will have a better understanding of how to

--- a/sessions/lightning-talks/shinyslack-connecting-slack-teams.md
+++ b/sessions/lightning-talks/shinyslack-connecting-slack-teams.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/jonthegeek/
     linkedin: https://www.linkedin.com/in/jonthegeek/
     affiliation: r4ds.io
-  slug: jon-harmon
+  username: jon-harmon
   photo: /assets/img/2022Conf/_talks/22108_jon-harmon.jpg
   bio: |+
     Jon runs the R4DS Online Learning Community and is the Principal Data

--- a/sessions/lightning-talks/shinyslack-connecting-slack-teams.md
+++ b/sessions/lightning-talks/shinyslack-connecting-slack-teams.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/jonthegeek/
     linkedin: https://www.linkedin.com/in/jonthegeek/
     affiliation: r4ds.io
-  username: jon-harmon
+  username: jon_harmon
   photo: /assets/img/2022Conf/_talks/22108_jon-harmon.jpg
   bio: |+
     Jon runs the R4DS Online Learning Community and is the Principal Data

--- a/sessions/lightning-talks/visualizing-distributions-uncertainty-using-ggdist.md
+++ b/sessions/lightning-talks/visualizing-distributions-uncertainty-using-ggdist.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/mjskay
     linkedin: ~
     affiliation: https://www.northwestern.edu/
-  slug: matthew-kay
+  username: matthew-kay
   photo: /assets/img/2022Conf/_talks/22228_matthew-kay.jpg
   bio: |+
     Matthew Kay is an Assistant Professor jointly appointed in Computer

--- a/sessions/lightning-talks/visualizing-distributions-uncertainty-using-ggdist.md
+++ b/sessions/lightning-talks/visualizing-distributions-uncertainty-using-ggdist.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/mjskay
     linkedin: ~
     affiliation: https://www.northwestern.edu/
-  username: matthew-kay
+  username: matthew_kay
   photo: /assets/img/2022Conf/_talks/22228_matthew-kay.jpg
   bio: |+
     Matthew Kay is an Assistant Professor jointly appointed in Computer

--- a/sessions/lightning-talks/webr-r-compiled-for-webassembly.md
+++ b/sessions/lightning-talks/webr-r-compiled-for-webassembly.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/georgestagg
     linkedin: ~
     affiliation: ~
-  username: george-stagg
+  username: george_stagg
   photo: /assets/img/2022Conf/_talks/22027_george-stagg.jpeg
   bio: |+
     George Stagg is a Software Engineer with experience in research

--- a/sessions/lightning-talks/webr-r-compiled-for-webassembly.md
+++ b/sessions/lightning-talks/webr-r-compiled-for-webassembly.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/georgestagg
     linkedin: ~
     affiliation: ~
-  slug: george-stagg
+  username: george-stagg
   photo: /assets/img/2022Conf/_talks/22027_george-stagg.jpeg
   bio: |+
     George Stagg is a Software Engineer with experience in research

--- a/sessions/lightning-talks/zero-setup-r-workshops-github.md
+++ b/sessions/lightning-talks/zero-setup-r-workshops-github.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/revodavid
     linkedin: https://www.linkedin.com/in/dmsmith/
     affiliation: https://www.microsoft.com
-  username: david-smith
+  username: david_smith
   photo: /assets/img/2022Conf/_talks/22056_david-smith.png
   bio: |+
     David is a Cloud Advocate for Microsoft, specializing in the

--- a/sessions/lightning-talks/zero-setup-r-workshops-github.md
+++ b/sessions/lightning-talks/zero-setup-r-workshops-github.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/revodavid
     linkedin: https://www.linkedin.com/in/dmsmith/
     affiliation: https://www.microsoft.com
-  username: david_smith
+  username: revodavid
   photo: /assets/img/2022Conf/_talks/22056_david-smith.png
   bio: |+
     David is a Cloud Advocate for Microsoft, specializing in the

--- a/sessions/lightning-talks/zero-setup-r-workshops-github.md
+++ b/sessions/lightning-talks/zero-setup-r-workshops-github.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/revodavid
     linkedin: https://www.linkedin.com/in/dmsmith/
     affiliation: https://www.microsoft.com
-  slug: david-smith
+  username: david-smith
   photo: /assets/img/2022Conf/_talks/22056_david-smith.png
   bio: |+
     David is a Cloud Advocate for Microsoft, specializing in the

--- a/sessions/machine-learning/dissecting-quick-fix-analysing-tech.md
+++ b/sessions/machine-learning/dissecting-quick-fix-analysing-tech.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/skeydan
     linkedin: https://de.linkedin.com/in/sigrid-keydana-9a16b410
     affiliation: https://blogs.rstudio.com/ai/
-  username: sigrid-keydana
+  username: sigrid_keydana
   photo: /assets/img/2022Conf/_talks/22008_sigrid-keydana.jpg
   bio: |+
     Sigrid works at RStudio, where she writes about open-source deep

--- a/sessions/machine-learning/dissecting-quick-fix-analysing-tech.md
+++ b/sessions/machine-learning/dissecting-quick-fix-analysing-tech.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/skeydan
     linkedin: https://de.linkedin.com/in/sigrid-keydana-9a16b410
     affiliation: https://blogs.rstudio.com/ai/
-  slug: sigrid-keydana
+  username: sigrid-keydana
   photo: /assets/img/2022Conf/_talks/22008_sigrid-keydana.jpg
   bio: |+
     Sigrid works at RStudio, where she writes about open-source deep

--- a/sessions/machine-learning/pull-bootstraps-generating-bootstrap-prediction.md
+++ b/sessions/machine-learning/pull-bootstraps-generating-bootstrap-prediction.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: ~
-  slug: mark-rieke
+  username: mark-rieke
   photo: /assets/img/2022Conf/_talks/22033_mark-rieke.png
   bio: |+
     I am the senior consumer experience (CX) analyst at Memorial Hermann

--- a/sessions/machine-learning/pull-bootstraps-generating-bootstrap-prediction.md
+++ b/sessions/machine-learning/pull-bootstraps-generating-bootstrap-prediction.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: ~
-  username: mark-rieke
+  username: mark_rieke
   photo: /assets/img/2022Conf/_talks/22033_mark-rieke.png
   bio: |+
     I am the senior consumer experience (CX) analyst at Memorial Hermann

--- a/sessions/machine-learning/tidysynthesis-r-package.md
+++ b/sessions/machine-learning/tidysynthesis-r-package.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/awunderground
     linkedin: https://www.linkedin.com/in/aaronrwilliams100
     affiliation: https://www.urban.org/
-  slug: aaron-r-williams
+  username: aaron-r-williams
   photo: /assets/img/2022Conf/_talks/22119_aaron-r-williams.jpeg
   bio: |+
     Aaron R. Williams is a senior data scientist at the Urban Institute

--- a/sessions/machine-learning/tidysynthesis-r-package.md
+++ b/sessions/machine-learning/tidysynthesis-r-package.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/awunderground
     linkedin: https://www.linkedin.com/in/aaronrwilliams100
     affiliation: https://www.urban.org/
-  username: aaron-r-williams
+  username: aaron_r_williams
   photo: /assets/img/2022Conf/_talks/22119_aaron-r-williams.jpeg
   bio: |+
     Aaron R. Williams is a senior data scientist at the Urban Institute

--- a/sessions/makeovers/adapting-current-tools-in-environmental.md
+++ b/sessions/makeovers/adapting-current-tools-in-environmental.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/hannah-podzorski
     affiliation: https://www.gsienv.com/
-  slug: hannah-podzorski
+  username: hannah-podzorski
   photo: /assets/img/2022Conf/_talks/22158_hannah-podzorski.jpg
   bio: |+
     Hannah Podzorski is a hydrologist currently working as an

--- a/sessions/makeovers/adapting-current-tools-in-environmental.md
+++ b/sessions/makeovers/adapting-current-tools-in-environmental.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/hannah-podzorski
     affiliation: https://www.gsienv.com/
-  username: hannah-podzorski
+  username: hannah_podzorski
   photo: /assets/img/2022Conf/_talks/22158_hannah-podzorski.jpg
   bio: |+
     Hannah Podzorski is a hydrologist currently working as an

--- a/sessions/makeovers/creating-data-input-platform-using.md
+++ b/sessions/makeovers/creating-data-input-platform-using.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/hezibu/
     linkedin: ~
     affiliation: https://belmaker.weebly.com/
-  slug: hezi-buba
+  username: hezi-buba
   photo: /assets/img/2022Conf/_talks/22070_hezi-buba.jpg
   bio: |+
     Hezi is currently finishing his PhD in marine ecology at Tel Aviv

--- a/sessions/makeovers/creating-data-input-platform-using.md
+++ b/sessions/makeovers/creating-data-input-platform-using.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/hezibu/
     linkedin: ~
     affiliation: https://belmaker.weebly.com/
-  username: hezi-buba
+  username: hezi_buba
   photo: /assets/img/2022Conf/_talks/22070_hezi-buba.jpg
   bio: |+
     Hezi is currently finishing his PhD in marine ecology at Tel Aviv

--- a/sessions/makeovers/inheritance-upgrading-legacy-project-making.md
+++ b/sessions/makeovers/inheritance-upgrading-legacy-project-making.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/eroten
     linkedin: https://www.linkedin.com/in/eroten
     affiliation: https://metrocouncil.org
-  username: liz-roten
+  username: liz_roten
   photo: /assets/img/2022Conf/_talks/22094_liz-roten.jpg
   bio: |+
     Liz Roten is a data scientist and cartographer in St. Paul, Minnesota.

--- a/sessions/makeovers/inheritance-upgrading-legacy-project-making.md
+++ b/sessions/makeovers/inheritance-upgrading-legacy-project-making.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/eroten
     linkedin: https://www.linkedin.com/in/eroten
     affiliation: https://metrocouncil.org
-  slug: liz-roten
+  username: liz-roten
   photo: /assets/img/2022Conf/_talks/22094_liz-roten.jpg
   bio: |+
     Liz Roten is a data scientist and cartographer in St. Paul, Minnesota.

--- a/sessions/makeovers/saving-1000-hours-rstudio.md
+++ b/sessions/makeovers/saving-1000-hours-rstudio.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/CodingTigerTang
     linkedin: https://www.linkedin.com/in/chongtaitang/
     affiliation: ~
-  username: tiger-tang
+  username: tiger_tang
   photo: /assets/img/2022Conf/_talks/22164_tiger-tang.jpg
   bio: |+
     Tiger(Chongtai) Tang is a Data Science Manager at CARFAX, dedicated

--- a/sessions/makeovers/saving-1000-hours-rstudio.md
+++ b/sessions/makeovers/saving-1000-hours-rstudio.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/CodingTigerTang
     linkedin: https://www.linkedin.com/in/chongtaitang/
     affiliation: ~
-  slug: tiger-tang
+  username: tiger-tang
   photo: /assets/img/2022Conf/_talks/22164_tiger-tang.jpg
   bio: |+
     Tiger(Chongtai) Tang is a Data Science Manager at CARFAX, dedicated

--- a/sessions/python/achieving-seamless-workflow-r-python.md
+++ b/sessions/python/achieving-seamless-workflow-r-python.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/melissavanbussel
     linkedin: https://www.linkedin.com/in/melissavanbussel/
     affiliation: https://www.statcan.gc.ca/en/start
-  username: melissa-van-bussel
+  username: melissa_van_bussel
   photo: /assets/img/2022Conf/_talks/22082_melissa-van-bussel.jpg
   bio: |+
     Melissa Van Bussel is an accredited [Associate Statistician](https://

--- a/sessions/python/achieving-seamless-workflow-r-python.md
+++ b/sessions/python/achieving-seamless-workflow-r-python.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/melissavanbussel
     linkedin: https://www.linkedin.com/in/melissavanbussel/
     affiliation: https://www.statcan.gc.ca/en/start
-  slug: melissa-van-bussel
+  username: melissa-van-bussel
   photo: /assets/img/2022Conf/_talks/22082_melissa-van-bussel.jpg
   bio: |+
     Melissa Van Bussel is an accredited [Associate Statistician](https://

--- a/sessions/python/designing-internal-tools-for-multi.md
+++ b/sessions/python/designing-internal-tools-for-multi.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/jamie-r-ralph
     affiliation: ~
-  username: jamie-ralph
+  username: jamie_ralph
   photo: /assets/img/2022Conf/_talks/22038_jamie-ralph.jpg
   bio: |+
     Jamie is a developer at Bumble where he builds internal analytics

--- a/sessions/python/designing-internal-tools-for-multi.md
+++ b/sessions/python/designing-internal-tools-for-multi.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/jamie-r-ralph
     affiliation: ~
-  slug: jamie-ralph
+  username: jamie-ralph
   photo: /assets/img/2022Conf/_talks/22038_jamie-ralph.jpg
   bio: |+
     Jamie is a developer at Bumble where he builds internal analytics

--- a/sessions/python/develop-deploy-python-rstudio.md
+++ b/sessions/python/develop-deploy-python-rstudio.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/gsingh91
     linkedin: https://www.linkedin.com/in/gagandeeepuw/
     affiliation: https://www.rstudio.com/about
-  slug: gagandeep-singh
+  username: gagandeep-singh
   photo: /assets/img/2022Conf/_talks/22126_gagandeep-singh.jpg
   bio: |+
     Gagandeep works as a Solutions Engineer with RStudio. He is a former
@@ -39,7 +39,7 @@ speakers:
     github: https://github.com/xuf12
     linkedin: https://www.linkedin.com/in/xufei1/
     affiliation: https://www.rstudio.com
-  slug: xu-fei
+  username: xu-fei
   photo: /assets/img/2022Conf/_talks/22126_xu-fei.png
   bio: |+
     Xu Fei is a solutions engineer at RStudio with experience building

--- a/sessions/python/develop-deploy-python-rstudio.md
+++ b/sessions/python/develop-deploy-python-rstudio.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/gsingh91
     linkedin: https://www.linkedin.com/in/gagandeeepuw/
     affiliation: https://www.rstudio.com/about
-  username: gagandeep-singh
+  username: gagandeep_singh
   photo: /assets/img/2022Conf/_talks/22126_gagandeep-singh.jpg
   bio: |+
     Gagandeep works as a Solutions Engineer with RStudio. He is a former
@@ -39,7 +39,7 @@ speakers:
     github: https://github.com/xuf12
     linkedin: https://www.linkedin.com/in/xufei1/
     affiliation: https://www.rstudio.com
-  username: xu-fei
+  username: xu_fei
   photo: /assets/img/2022Conf/_talks/22126_xu-fei.png
   bio: |+
     Xu Fei is a solutions engineer at RStudio with experience building

--- a/sessions/python/running-shiny-without-server.md
+++ b/sessions/python/running-shiny-without-server.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/wch
     linkedin: ~
     affiliation: https://rstudio.com
-  slug: winston-chang
+  username: winston-chang
   photo: /assets/img/2022Conf/_talks/22232_winston-chang.jpeg
   bio: |+
     Winston Chang is a software engineer at RStudio and currently works

--- a/sessions/python/running-shiny-without-server.md
+++ b/sessions/python/running-shiny-without-server.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/wch
     linkedin: ~
     affiliation: https://rstudio.com
-  username: winston-chang
+  username: winston_chang
   photo: /assets/img/2022Conf/_talks/22232_winston-chang.jpeg
   bio: |+
     Winston Chang is a software engineer at RStudio and currently works

--- a/sessions/quarto-deep-dive/literate-programming-quarto.md
+++ b/sessions/quarto-deep-dive/literate-programming-quarto.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/hamelsmu
     linkedin: https://www.linkedin.com/in/hamelhusain/
     affiliation: https://github.com/fastai
-  slug: nbdev-quarto
+  username: nbdev-quarto
   photo: https://github.com/hamelsmu.png
   bio: |+
     Hamel Husain is head of Data Science and ML at

--- a/sessions/quarto-deep-dive/literate-programming-quarto.md
+++ b/sessions/quarto-deep-dive/literate-programming-quarto.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/hamelsmu
     linkedin: https://www.linkedin.com/in/hamelhusain/
     affiliation: https://github.com/fastai
-  username: nbdev-quarto
+  username: nbdev_quarto
   photo: https://github.com/hamelsmu.png
   bio: |+
     Hamel Husain is head of Data Science and ML at

--- a/sessions/quarto-deep-dive/my-favorite-things-quarto-presentations.md
+++ b/sessions/quarto-deep-dive/my-favorite-things-quarto-presentations.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/tracykteal
     linkedin: https://www.linkedin.com/in/tracy-teal-059136b/
     affiliation: https://www.rstudio.com/
-  slug: tracy-teal
+  username: tracy-teal
   photo: /assets/img/2022Conf/_talks/22044_tracy-teal.jpg
   bio: |+
     Tracy Teal has been working with open source communities as a

--- a/sessions/quarto-deep-dive/my-favorite-things-quarto-presentations.md
+++ b/sessions/quarto-deep-dive/my-favorite-things-quarto-presentations.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/tracykteal
     linkedin: https://www.linkedin.com/in/tracy-teal-059136b/
     affiliation: https://www.rstudio.com/
-  username: tracy-teal
+  username: tracy_teal
   photo: /assets/img/2022Conf/_talks/22044_tracy-teal.jpg
   bio: |+
     Tracy Teal has been working with open source communities as a

--- a/sessions/quarto-deep-dive/websites-books-blogs-oh-creating.md
+++ b/sessions/quarto-deep-dive/websites-books-blogs-oh-creating.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: ~
-  username: devin-pastoor
+  username: devin_pastoor
   photo: /assets/img/2022Conf/_talks/22234_devin-pastoor.png
   bio: |+
     Devin is a solutions engineer at RStudio. He has a PhD in

--- a/sessions/quarto-deep-dive/websites-books-blogs-oh-creating.md
+++ b/sessions/quarto-deep-dive/websites-books-blogs-oh-creating.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: ~
-  slug: devin-pastoor
+  username: devin-pastoor
   photo: /assets/img/2022Conf/_talks/22234_devin-pastoor.png
   bio: |+
     Devin is a solutions engineer at RStudio. He has a PhD in

--- a/sessions/r-in-pharma/dive-deep-metadata-tplyr.md
+++ b/sessions/r-in-pharma/dive-deep-metadata-tplyr.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/mstackhouse
     linkedin: https://www.linkedin.com/in/michael-s-stackhouse/
     affiliation: https://www.atorusresearch.com/
-  slug: mike-stackhouse
+  username: mike-stackhouse
   photo: /assets/img/2022Conf/_talks/22194_mike-stackhouse.jpg
   bio: |+
     Mike Stackhouse is the Chief Innovation Officer of Atorus Research

--- a/sessions/r-in-pharma/dive-deep-metadata-tplyr.md
+++ b/sessions/r-in-pharma/dive-deep-metadata-tplyr.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/mstackhouse
     linkedin: https://www.linkedin.com/in/michael-s-stackhouse/
     affiliation: https://www.atorusresearch.com/
-  username: mike-stackhouse
+  username: mike_stackhouse
   photo: /assets/img/2022Conf/_talks/22194_mike-stackhouse.jpg
   bio: |+
     Mike Stackhouse is the Chief Innovation Officer of Atorus Research

--- a/sessions/r-in-pharma/packages-and-process.md
+++ b/sessions/r-in-pharma/packages-and-process.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/thebioengineer
     linkedin: https://linkedin.com/in/ellishughes
     affiliation: https://gsk.com
-  slug: ellis-hughes
+  username: ellis-hughes
   photo: /assets/img/2022Conf/_talks/22209_ellis-hughes.jpg
   bio: |+
     Ellis Hughes is a Data Science Leader and has worked in the

--- a/sessions/r-in-pharma/packages-and-process.md
+++ b/sessions/r-in-pharma/packages-and-process.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/thebioengineer
     linkedin: https://linkedin.com/in/ellishughes
     affiliation: https://gsk.com
-  username: ellis-hughes
+  username: ellis_hughes
   photo: /assets/img/2022Conf/_talks/22209_ellis-hughes.jpg
   bio: |+
     Ellis Hughes is a Data Science Leader and has worked in the

--- a/sessions/r-in-pharma/r-package-assessment-lessons-pharma.md
+++ b/sessions/r-in-pharma/r-package-assessment-lessons-pharma.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: ~
-  username: becca-krouse
+  username: becca_krouse
   photo: /assets/img/2022Conf/_talks/22192_becca-krouse.png
   bio: |+
     Becca Krouse is a Data Science Leader in the Statistics and Data

--- a/sessions/r-in-pharma/r-package-assessment-lessons-pharma.md
+++ b/sessions/r-in-pharma/r-package-assessment-lessons-pharma.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: ~
-  slug: becca-krouse
+  username: becca-krouse
   photo: /assets/img/2022Conf/_talks/22192_becca-krouse.png
   bio: |+
     Becca Krouse is a Data Science Leader in the Statistics and Data

--- a/sessions/rapid-response/anchorage-built-alaskas-vaccine-finder.md
+++ b/sessions/rapid-response/anchorage-built-alaskas-vaccine-finder.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/benmatheson
     linkedin: https://www.linkedin.com/in/benmatheson
     affiliation: https://muni.org
-  slug: ben-matheson
+  username: ben-matheson
   photo: /assets/img/2022Conf/_talks/22139_ben-matheson.jpg
   bio: |+
     Ben Matheson is the Data Analyst for the Anchorage Innovation Team—

--- a/sessions/rapid-response/anchorage-built-alaskas-vaccine-finder.md
+++ b/sessions/rapid-response/anchorage-built-alaskas-vaccine-finder.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/benmatheson
     linkedin: https://www.linkedin.com/in/benmatheson
     affiliation: https://muni.org
-  username: ben-matheson
+  username: ben_matheson
   photo: /assets/img/2022Conf/_talks/22139_ben-matheson.jpg
   bio: |+
     Ben Matheson is the Data Analyst for the Anchorage Innovation Team—

--- a/sessions/rapid-response/integrated-workflow-azure-devops-rstudio.md
+++ b/sessions/rapid-response/integrated-workflow-azure-devops-rstudio.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/lytello
     affiliation: https://www.cdph.ca.gov/
-  username: lawrence-y-tello
+  username: lawrence_y_tello
   photo: /assets/img/2022Conf/_talks/22227_lawrence-y-tello.jpg
   bio: |+
     Lawrence is an informatics specialist at the California Department

--- a/sessions/rapid-response/integrated-workflow-azure-devops-rstudio.md
+++ b/sessions/rapid-response/integrated-workflow-azure-devops-rstudio.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/lytello
     affiliation: https://www.cdph.ca.gov/
-  slug: lawrence-y-tello
+  username: lawrence-y-tello
   photo: /assets/img/2022Conf/_talks/22227_lawrence-y-tello.jpg
   bio: |+
     Lawrence is an informatics specialist at the California Department

--- a/sessions/rapid-response/optimal-allocation-of-covid-19.md
+++ b/sessions/rapid-response/optimal-allocation-of-covid-19.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: ~
-  slug: allison-fox
+  username: allison-fox
   photo: /assets/img/2022Conf/_talks/22230_allison-fox.jpg
   bio: |+
     Allison Fox is a senior associate in data science who supports a range
@@ -42,7 +42,7 @@ speakers:
     github: https://github.com/anu87
     linkedin: https://www.linkedin.com/in/anubhuti-mishra-1958298/
     affiliation: https://datafi.thepalladiumgroup.com/
-  slug: anubhuti-mishra
+  username: anubhuti-mishra
   photo: /assets/img/2022Conf/_talks/22230_anubhuti-mishra.png
   bio: |+
     Anubhuti Mishra is a Senior Data Scientist who works at the

--- a/sessions/rapid-response/optimal-allocation-of-covid-19.md
+++ b/sessions/rapid-response/optimal-allocation-of-covid-19.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: ~
-  username: allison-fox
+  username: allison_fox
   photo: /assets/img/2022Conf/_talks/22230_allison-fox.jpg
   bio: |+
     Allison Fox is a senior associate in data science who supports a range
@@ -42,7 +42,7 @@ speakers:
     github: https://github.com/anu87
     linkedin: https://www.linkedin.com/in/anubhuti-mishra-1958298/
     affiliation: https://datafi.thepalladiumgroup.com/
-  username: anubhuti-mishra
+  username: anubhuti_mishra
   photo: /assets/img/2022Conf/_talks/22230_anubhuti-mishra.png
   bio: |+
     Anubhuti Mishra is a Senior Data Scientist who works at the

--- a/sessions/rapid-response/scaling-automating-r-workflows-kubernetes.md
+++ b/sessions/rapid-response/scaling-automating-r-workflows-kubernetes.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/isaac-florence
     linkedin: https://uk.linkedin.com/in/isaacflorence
     affiliation: https://www.gov.uk/government/organisations/uk-health-security-agency
-  slug: isaac-florence
+  username: isaac-florence
   photo: /assets/img/2022Conf/_talks/22199_isaac-florence.jpg
   bio: |+
     I am an epidemiologist and public health policy professional working

--- a/sessions/rapid-response/scaling-automating-r-workflows-kubernetes.md
+++ b/sessions/rapid-response/scaling-automating-r-workflows-kubernetes.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/isaac-florence
     linkedin: https://uk.linkedin.com/in/isaacflorence
     affiliation: https://www.gov.uk/government/organisations/uk-health-security-agency
-  username: isaac-florence
+  username: isaac_florence
   photo: /assets/img/2022Conf/_talks/22199_isaac-florence.jpg
   bio: |+
     I am an epidemiologist and public health policy professional working

--- a/sessions/rmarkdown-quarto/highlights-of-knitr-package-past.md
+++ b/sessions/rmarkdown-quarto/highlights-of-knitr-package-past.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/yihui
     linkedin: ~
     affiliation: ~
-  username: yihui-xie
+  username: yihui_xie
   photo: /assets/img/2022Conf/_talks/22181_yihui-xie.png
   bio: |+
     Yihui Xie is a software engineer at RStudio. He earned his PhD from

--- a/sessions/rmarkdown-quarto/highlights-of-knitr-package-past.md
+++ b/sessions/rmarkdown-quarto/highlights-of-knitr-package-past.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/yihui
     linkedin: ~
     affiliation: ~
-  slug: yihui-xie
+  username: yihui-xie
   photo: /assets/img/2022Conf/_talks/22181_yihui-xie.png
   bio: |+
     Yihui Xie is a software engineer at RStudio. He earned his PhD from

--- a/sessions/rmarkdown-quarto/quarto-for-rmarkdown-users.md
+++ b/sessions/rmarkdown-quarto/quarto-for-rmarkdown-users.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/jthomasmock
     linkedin: https://www.linkedin.com/in/jthomasmock/
     affiliation: https://www.rstudio.com/about/
-  username: tom-mock
+  username: tom_mock
   photo: /assets/img/2022Conf/_talks/22149_tom-mock.jpeg
   bio: |+
     Thomas is the Customer Enablement Lead at RStudio, helping RStudio’s

--- a/sessions/rmarkdown-quarto/quarto-for-rmarkdown-users.md
+++ b/sessions/rmarkdown-quarto/quarto-for-rmarkdown-users.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/jthomasmock
     linkedin: https://www.linkedin.com/in/jthomasmock/
     affiliation: https://www.rstudio.com/about/
-  slug: tom-mock
+  username: tom-mock
   photo: /assets/img/2022Conf/_talks/22149_tom-mock.jpeg
   bio: |+
     Thomas is the Customer Enablement Lead at RStudio, helping RStudio’s

--- a/sessions/rmarkdown-quarto/sometimes-you-just-need-words.md
+++ b/sessions/rmarkdown-quarto/sometimes-you-just-need-words.md
@@ -21,7 +21,7 @@ speakers:
     github: https://lmkirvan.github.io/index.html
     linkedin: https://www.linkedin.com/in/lewis-kirvan-9013392b/
     affiliation: https://www.consumerfinance.gov/
-  username: lewis-kirvan
+  username: lewis_kirvan
   photo: /assets/img/2022Conf/_talks/22175_lewis-kirvan.jpg
   bio: |+
     I'm a researcher at the Consumer Financial Protection Bureau, where

--- a/sessions/rmarkdown-quarto/sometimes-you-just-need-words.md
+++ b/sessions/rmarkdown-quarto/sometimes-you-just-need-words.md
@@ -21,7 +21,7 @@ speakers:
     github: https://lmkirvan.github.io/index.html
     linkedin: https://www.linkedin.com/in/lewis-kirvan-9013392b/
     affiliation: https://www.consumerfinance.gov/
-  slug: lewis-kirvan
+  username: lewis-kirvan
   photo: /assets/img/2022Conf/_talks/22175_lewis-kirvan.jpg
   bio: |+
     I'm a researcher at the Consumer Financial Protection Bureau, where

--- a/sessions/shiny-app-design/creating-design-system-for-shiny.md
+++ b/sessions/shiny-app-design/creating-design-system-for-shiny.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/MayaGans
     linkedin: https://www.linkedin.com/in/mayagans/
     affiliation: https://www.atorusresearch.com/
-  slug: maya-gans
+  username: maya-gans
   photo: /assets/img/2022Conf/_talks/22109_maya-gans.png
   bio: |+
     Maya Gans is an experienced R and JavaScript developer, who recently

--- a/sessions/shiny-app-design/creating-design-system-for-shiny.md
+++ b/sessions/shiny-app-design/creating-design-system-for-shiny.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/MayaGans
     linkedin: https://www.linkedin.com/in/mayagans/
     affiliation: https://www.atorusresearch.com/
-  username: maya-gans
+  username: maya_gans
   photo: /assets/img/2022Conf/_talks/22109_maya-gans.png
   bio: |+
     Maya Gans is an experienced R and JavaScript developer, who recently

--- a/sessions/shiny-app-design/dashboard-builder-making-truly-interactive.md
+++ b/sessions/shiny-app-design/dashboard-builder-making-truly-interactive.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/petergandenberger/
     linkedin: https://www.linkedin.com/in/peter-gandenberger-a7a2ba172/
     affiliation: ~
-  slug: peter-gandenberger
+  username: peter-gandenberger
   photo: /assets/img/2022Conf/_talks/22178_peter-gandenberger.jpg
   bio: |+
     Peter is about to finish his Masters in Data Engineering & Analytics
@@ -38,7 +38,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: ~
-  slug: andreas-hofheinz
+  username: andreas-hofheinz
   photo: /assets/img/2022Conf/_talks/22178_andreas-hofheinz.jpg
   bio: |+
     Andreas is a consultant at d-fine and maintainer of the leafdown R

--- a/sessions/shiny-app-design/dashboard-builder-making-truly-interactive.md
+++ b/sessions/shiny-app-design/dashboard-builder-making-truly-interactive.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/petergandenberger/
     linkedin: https://www.linkedin.com/in/peter-gandenberger-a7a2ba172/
     affiliation: ~
-  username: peter-gandenberger
+  username: peter_gandenberger
   photo: /assets/img/2022Conf/_talks/22178_peter-gandenberger.jpg
   bio: |+
     Peter is about to finish his Masters in Data Engineering & Analytics
@@ -38,7 +38,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: ~
-  username: andreas-hofheinz
+  username: andreas_hofheinz
   photo: /assets/img/2022Conf/_talks/22178_andreas-hofheinz.jpg
   bio: |+
     Andreas is a consultant at d-fine and maintainer of the leafdown R

--- a/sessions/shiny-app-design/dashboard-builder-making-truly-interactive.md
+++ b/sessions/shiny-app-design/dashboard-builder-making-truly-interactive.md
@@ -31,21 +31,7 @@ speakers:
     shiny dashboards without writing R-code.
 
 - name: Andreas Hofheinz
-  affiliation: ~
-  url:
-    webpage: ~
-    twitter: ~
-    github: ~
-    linkedin: ~
-    affiliation: ~
   username: andreas_hofheinz
-  photo: /assets/img/2022Conf/_talks/22178_andreas-hofheinz.jpg
-  bio: |+
-    Andreas is a consultant at d-fine and maintainer of the leafdown R
-    package. He is passionate about interactive data visualizations and
-    interpretable machine learning. He holds a B.Sc. in Economics and an
-    M.Sc. in Statistics from LMU Munich.
-
 
 ---
 

--- a/sessions/shiny-app-design/new-way-to-build-shiny.md
+++ b/sessions/shiny-app-design/new-way-to-build-shiny.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/nstrayer
     linkedin: https://www.linkedin.com/in/nickstrayer/
     affiliation: https://shiny.rstudio.com/
-  slug: nick-strayer
+  username: nick-strayer
   photo: /assets/img/2022Conf/_talks/22058_nick-strayer.jpg
   bio: |+
     Nick is an engineer on the Shiny team working to make web applications

--- a/sessions/shiny-app-design/new-way-to-build-shiny.md
+++ b/sessions/shiny-app-design/new-way-to-build-shiny.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/nstrayer
     linkedin: https://www.linkedin.com/in/nickstrayer/
     affiliation: https://shiny.rstudio.com/
-  username: nick-strayer
+  username: nick_strayer
   photo: /assets/img/2022Conf/_talks/22058_nick-strayer.jpg
   bio: |+
     Nick is an engineer on the Shiny team working to make web applications

--- a/sessions/shiny-app-design/whats-new-in-shiny-ui.md
+++ b/sessions/shiny-app-design/whats-new-in-shiny-ui.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/gregswinehart/
     affiliation: https://www.rstudio.com/
-  username: greg-swinehart
+  username: greg_swinehart
   photo: /assets/img/2022Conf/_talks/22063_greg-swinehart.jpg
   bio: |+
     Greg has contributed to RStudio's brand, print and web designs

--- a/sessions/shiny-app-design/whats-new-in-shiny-ui.md
+++ b/sessions/shiny-app-design/whats-new-in-shiny-ui.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: https://www.linkedin.com/in/gregswinehart/
     affiliation: https://www.rstudio.com/
-  slug: greg-swinehart
+  username: greg-swinehart
   photo: /assets/img/2022Conf/_talks/22063_greg-swinehart.jpg
   bio: |+
     Greg has contributed to RStudio's brand, print and web designs

--- a/sessions/teaching-data-science/designing-socially-critical-data-science.md
+++ b/sessions/teaching-data-science/designing-socially-critical-data-science.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/briandk/
     linkedin: https://www.linkedin.com/in/briandanielak/
     affiliation: http://briandk.github.io/
-  username: brian-danielak
+  username: brian_danielak
   photo: /assets/img/2022Conf/_talks/22222_brian-danielak.jpg
   bio: |+
     Brian's career has spanned teaching, researching, and being a

--- a/sessions/teaching-data-science/designing-socially-critical-data-science.md
+++ b/sessions/teaching-data-science/designing-socially-critical-data-science.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/briandk/
     linkedin: https://www.linkedin.com/in/briandanielak/
     affiliation: http://briandk.github.io/
-  slug: brian-danielak
+  username: brian-danielak
   photo: /assets/img/2022Conf/_talks/22222_brian-danielak.jpg
   bio: |+
     Brian's career has spanned teaching, researching, and being a

--- a/sessions/teaching-data-science/mobile-low-bandwidth-low-tech.md
+++ b/sessions/teaching-data-science/mobile-low-bandwidth-low-tech.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/dietrichson
     linkedin: https://www.linkedin.com/in/dietrichson/
     affiliation: http://www.chi2labs.com
-  slug: aleksander-dietrichson
+  username: aleksander-dietrichson
   photo: /assets/img/2022Conf/_talks/22212_aleksander-dietrichson.png
   bio: |+
     Aleksander (Sasha) Dietrichson, Phd is a professor of Data Science and

--- a/sessions/teaching-data-science/mobile-low-bandwidth-low-tech.md
+++ b/sessions/teaching-data-science/mobile-low-bandwidth-low-tech.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/dietrichson
     linkedin: https://www.linkedin.com/in/dietrichson/
     affiliation: http://www.chi2labs.com
-  username: aleksander-dietrichson
+  username: aleksander_dietrichson
   photo: /assets/img/2022Conf/_talks/22212_aleksander-dietrichson.png
   bio: |+
     Aleksander (Sasha) Dietrichson, Phd is a professor of Data Science and

--- a/sessions/teaching-data-science/teaching-bilingual-classes-tidymodels-scikit.md
+++ b/sessions/teaching-data-science/teaching-bilingual-classes-tidymodels-scikit.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/kbodwin
     linkedin: ~
     affiliation: statistics.calpoly.edu
-  username: kelly-bodwin
+  username: kelly_bodwin
   photo: /assets/img/2022Conf/_talks/22047_kelly-bodwin.jpg
   bio: |+
     Kelly Bodwin is an Assistant Professor of Statistics and Data

--- a/sessions/teaching-data-science/teaching-bilingual-classes-tidymodels-scikit.md
+++ b/sessions/teaching-data-science/teaching-bilingual-classes-tidymodels-scikit.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/kbodwin
     linkedin: ~
     affiliation: statistics.calpoly.edu
-  slug: kelly-bodwin
+  username: kelly-bodwin
   photo: /assets/img/2022Conf/_talks/22047_kelly-bodwin.jpg
   bio: |+
     Kelly Bodwin is an Assistant Professor of Statistics and Data

--- a/sessions/tidymodels/celery-expanding-tidymodels-to-clustering.md
+++ b/sessions/tidymodels/celery-expanding-tidymodels-to-clustering.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/emilhvitfeldt
     linkedin: https://www.linkedin.com/in/emilhvitfeldt/
     affiliation: https://www.rstudio.com/
-  username: emil-hvitfeldt
+  username: emil_hvitfeldt
   photo: /assets/img/2022Conf/_talks/22098_emil-hvitfeldt.png
   bio: |+
     Emil Hvitfeldt is a software engineer at RStudio. Part of the

--- a/sessions/tidymodels/celery-expanding-tidymodels-to-clustering.md
+++ b/sessions/tidymodels/celery-expanding-tidymodels-to-clustering.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/emilhvitfeldt
     linkedin: https://www.linkedin.com/in/emilhvitfeldt/
     affiliation: https://www.rstudio.com/
-  slug: emil-hvitfeldt
+  username: emil-hvitfeldt
   photo: /assets/img/2022Conf/_talks/22098_emil-hvitfeldt.png
   bio: |+
     Emil Hvitfeldt is a software engineer at RStudio. Part of the

--- a/sessions/tidymodels/censored-survival-analysis-in-tidymodels.md
+++ b/sessions/tidymodels/censored-survival-analysis-in-tidymodels.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/hfrick
     linkedin: https://www.linkedin.com/in/hannah-frick
     affiliation: https://www.rstudio.com/
-  username: hannah-frick
+  username: hannah_frick
   photo: /assets/img/2022Conf/_talks/22073_hannah-frick.jpeg
   bio: |+
     Hannah Frick is a software engineer on the tidymodels team at

--- a/sessions/tidymodels/censored-survival-analysis-in-tidymodels.md
+++ b/sessions/tidymodels/censored-survival-analysis-in-tidymodels.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/hfrick
     linkedin: https://www.linkedin.com/in/hannah-frick
     affiliation: https://www.rstudio.com/
-  slug: hannah-frick
+  username: hannah-frick
   photo: /assets/img/2022Conf/_talks/22073_hannah-frick.jpeg
   bio: |+
     Hannah Frick is a software engineer on the tidymodels team at

--- a/sessions/tidymodels/demystifying-mlops.md
+++ b/sessions/tidymodels/demystifying-mlops.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/isabelizimm
     linkedin: https://www.linkedin.com/in/isabel-zimmerman/
     affiliation: https://www.rstudio.com/
-  username: isabel-zimmerman
+  username: isabel_zimmerman
   photo: /assets/img/2022Conf/_talks/22166_isabel-zimmerman.jpg
   bio: |+
     Isabel Zimmerman is a software engineer on the open source team at

--- a/sessions/tidymodels/demystifying-mlops.md
+++ b/sessions/tidymodels/demystifying-mlops.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/isabelizimm
     linkedin: https://www.linkedin.com/in/isabel-zimmerman/
     affiliation: https://www.rstudio.com/
-  slug: isabel-zimmerman
+  username: isabel-zimmerman
   photo: /assets/img/2022Conf/_talks/22166_isabel-zimmerman.jpg
   bio: |+
     Isabel Zimmerman is a software engineer on the open source team at

--- a/sessions/unexpected-uses/introduction-to-apple-health-export.md
+++ b/sessions/unexpected-uses/introduction-to-apple-health-export.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/johngoldin
     linkedin: ~
     affiliation: https://oir.yale.edu
-  username: john-goldin
+  username: john_goldin
   photo: /assets/img/2022Conf/_talks/22156_john-goldin.jpeg
   bio: |+
     John Goldin spent his career as a data analyst for the Yale University

--- a/sessions/unexpected-uses/introduction-to-apple-health-export.md
+++ b/sessions/unexpected-uses/introduction-to-apple-health-export.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/johngoldin
     linkedin: ~
     affiliation: https://oir.yale.edu
-  slug: john-goldin
+  username: john-goldin
   photo: /assets/img/2022Conf/_talks/22156_john-goldin.jpeg
   bio: |+
     John Goldin spent his career as a data analyst for the Yale University

--- a/sessions/unexpected-uses/made-entire-e-commerce-platform.md
+++ b/sessions/unexpected-uses/made-entire-e-commerce-platform.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/jnolis/ggirl
     linkedin: ~
     affiliation: ~
-  slug: jacqueline-nolis
+  username: jacqueline-nolis
   photo: /assets/img/2022Conf/_talks/22065_jacqueline-nolis.jpg
   bio: |+
     Dr. Jacqueline Nolis is a data science leader with 15 years of

--- a/sessions/unexpected-uses/made-entire-e-commerce-platform.md
+++ b/sessions/unexpected-uses/made-entire-e-commerce-platform.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/jnolis/ggirl
     linkedin: ~
     affiliation: ~
-  username: jacqueline-nolis
+  username: jacqueline_nolis
   photo: /assets/img/2022Conf/_talks/22065_jacqueline-nolis.jpg
   bio: |+
     Dr. Jacqueline Nolis is a data science leader with 15 years of

--- a/sessions/unexpected-uses/touch-of-r-in-robotics.md
+++ b/sessions/unexpected-uses/touch-of-r-in-robotics.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/R-icntay
     linkedin: ~
     affiliation: https://lida.leeds.ac.uk/
-  username: eric-wanjau
+  username: eric_wanjau
   photo: /assets/img/2022Conf/_talks/22132_eric-wanjau.png
   bio: |+
     Eric is an Early Career Researcher who continually seeks to tackle
@@ -43,7 +43,7 @@ speakers:
     github: https://github.com/ian011
     linkedin: ~
     affiliation: https://www.dkut.ac.ke/ and https://sunculture.com/
-  username: ian-muchiri
+  username: ian_muchiri
   photo: /assets/img/2022Conf/_talks/22132_ian-muchiri.png
   bio: |+
     I am a co-founder and co-organizer of DekutR data science club at

--- a/sessions/unexpected-uses/touch-of-r-in-robotics.md
+++ b/sessions/unexpected-uses/touch-of-r-in-robotics.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/R-icntay
     linkedin: ~
     affiliation: https://lida.leeds.ac.uk/
-  slug: eric-wanjau
+  username: eric-wanjau
   photo: /assets/img/2022Conf/_talks/22132_eric-wanjau.png
   bio: |+
     Eric is an Early Career Researcher who continually seeks to tackle
@@ -43,7 +43,7 @@ speakers:
     github: https://github.com/ian011
     linkedin: ~
     affiliation: https://www.dkut.ac.ke/ and https://sunculture.com/
-  slug: ian-muchiri
+  username: ian-muchiri
   photo: /assets/img/2022Conf/_talks/22132_ian-muchiri.png
   bio: |+
     I am a co-founder and co-organizer of DekutR data science club at

--- a/sessions/unexpected-uses/worlds-smallest-r-environment-running.md
+++ b/sessions/unexpected-uses/worlds-smallest-r-environment-running.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/sellorm
     linkedin: https://www.linkedin.com/in/msellors/
     affiliation: https://r4pi.org
-  slug: mark-sellors
+  username: mark-sellors
   photo: /assets/img/2022Conf/_talks/22105_mark-sellors.jpg
   bio: |+
     A life-long technologist, Mark has always been fascinated by the

--- a/sessions/unexpected-uses/worlds-smallest-r-environment-running.md
+++ b/sessions/unexpected-uses/worlds-smallest-r-environment-running.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/sellorm
     linkedin: https://www.linkedin.com/in/msellors/
     affiliation: https://r4pi.org
-  username: mark-sellors
+  username: mark_sellors
   photo: /assets/img/2022Conf/_talks/22105_mark-sellors.jpg
   bio: |+
     A life-long technologist, Mark has always been fascinated by the

--- a/sessions/working-with-code/cultivating-r-ecosystem-solo-contributor.md
+++ b/sessions/working-with-code/cultivating-r-ecosystem-solo-contributor.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/meghall06/
     linkedin: ~
     affiliation: ~
-  username: meghan-hall
+  username: meghan_hall
   photo: /assets/img/2022Conf/_talks/22041_meghan-hall.jpeg
   bio: |+
     Meghan Hall has spent over seven years as a data professional in

--- a/sessions/working-with-code/cultivating-r-ecosystem-solo-contributor.md
+++ b/sessions/working-with-code/cultivating-r-ecosystem-solo-contributor.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/meghall06/
     linkedin: ~
     affiliation: ~
-  slug: meghan-hall
+  username: meghan-hall
   photo: /assets/img/2022Conf/_talks/22041_meghan-hall.jpeg
   bio: |+
     Meghan Hall has spent over seven years as a data professional in

--- a/sessions/working-with-code/demystifying-art-of-creating-custom.md
+++ b/sessions/working-with-code/demystifying-art-of-creating-custom.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/dcaley5005?tab=repositories
     linkedin: https://www.linkedin.com/in/daniel-caley/
     affiliation: https://www.customink.com/about
-  username: dan-caley
+  username: dan_caley
   photo: /assets/img/2022Conf/_talks/22054_dan-caley.jpg
   bio: |+
     Dan Caley is a Senior Data Analyst at Custom Ink covering descriptive,

--- a/sessions/working-with-code/demystifying-art-of-creating-custom.md
+++ b/sessions/working-with-code/demystifying-art-of-creating-custom.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/dcaley5005?tab=repositories
     linkedin: https://www.linkedin.com/in/daniel-caley/
     affiliation: https://www.customink.com/about
-  slug: dan-caley
+  username: dan-caley
   photo: /assets/img/2022Conf/_talks/22054_dan-caley.jpg
   bio: |+
     Dan Caley is a Senior Data Analyst at Custom Ink covering descriptive,

--- a/sessions/working-with-code/shiny-dashboards-for-biomedical-research.md
+++ b/sessions/working-with-code/shiny-dashboards-for-biomedical-research.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: https://www.niaid.nih.gov/
-  username: jon-nye
+  username: jon_nye
   photo: /assets/img/2022Conf/_talks/22121_jon-nye.png
   bio: |+
     Jon Nye is a Lead Health Science Policy Analyst at the National

--- a/sessions/working-with-code/shiny-dashboards-for-biomedical-research.md
+++ b/sessions/working-with-code/shiny-dashboards-for-biomedical-research.md
@@ -21,7 +21,7 @@ speakers:
     github: ~
     linkedin: ~
     affiliation: https://www.niaid.nih.gov/
-  slug: jon-nye
+  username: jon-nye
   photo: /assets/img/2022Conf/_talks/22121_jon-nye.png
   bio: |+
     Jon Nye is a Lead Health Science Policy Analyst at the National

--- a/sessions/working-with-code/you-should-use-renv.md
+++ b/sessions/working-with-code/you-should-use-renv.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/edavidaja
     linkedin: https://linkedin.com/in/edavidaja
     affiliation: https://RStudio.com
-  slug: e-david-aja
+  username: e-david-aja
   photo: /assets/img/2022Conf/_talks/22067_e-david-aja.jpg
   bio: |+
     E. David Aja is a Solutions Engineer at RStudio. He helps data

--- a/sessions/working-with-code/you-should-use-renv.md
+++ b/sessions/working-with-code/you-should-use-renv.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/edavidaja
     linkedin: https://linkedin.com/in/edavidaja
     affiliation: https://RStudio.com
-  username: e-david-aja
+  username: e_david_aja
   photo: /assets/img/2022Conf/_talks/22067_e-david-aja.jpg
   bio: |+
     E. David Aja is a Solutions Engineer at RStudio. He helps data

--- a/sessions/working-with-people/benefit-of-talking-to-non-datas.md
+++ b/sessions/working-with-people/benefit-of-talking-to-non-datas.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/carobuck
     linkedin: https://www.linkedin.com/in/caro-buck/
     affiliation: https://www.wundermanthompson.com/
-  username: caro-buck
+  username: caro_buck
   photo: /assets/img/2022Conf/_talks/22025_caro-buck.jpg
   bio: |+
     I’m Caro, short for Caroline! I’m a curious and creative human, with

--- a/sessions/working-with-people/benefit-of-talking-to-non-datas.md
+++ b/sessions/working-with-people/benefit-of-talking-to-non-datas.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/carobuck
     linkedin: https://www.linkedin.com/in/caro-buck/
     affiliation: https://www.wundermanthompson.com/
-  slug: caro-buck
+  username: caro-buck
   photo: /assets/img/2022Conf/_talks/22025_caro-buck.jpg
   bio: |+
     I’m Caro, short for Caroline! I’m a curious and creative human, with

--- a/sessions/working-with-people/cross-industry-anomaly-detection-solutions.md
+++ b/sessions/working-with-people/cross-industry-anomaly-detection-solutions.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/tcash21
     linkedin: https://www.linkedin.com/in/tanyacashorali/
     affiliation: http://www.tcbanalytics.com
-  slug: tanya-cashorali
+  username: tanya-cashorali
   photo: /assets/img/2022Conf/_talks/22191_tanya-cashorali.jpg
   bio: |+
     Tanya Cashorali is the founder of TCB Analytics, a boutique data and

--- a/sessions/working-with-people/cross-industry-anomaly-detection-solutions.md
+++ b/sessions/working-with-people/cross-industry-anomaly-detection-solutions.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/tcash21
     linkedin: https://www.linkedin.com/in/tanyacashorali/
     affiliation: http://www.tcbanalytics.com
-  username: tanya-cashorali
+  username: tanya_cashorali
   photo: /assets/img/2022Conf/_talks/22191_tanya-cashorali.jpg
   bio: |+
     Tanya Cashorali is the founder of TCB Analytics, a boutique data and

--- a/sessions/working-with-people/enterprise-level-data-science-success.md
+++ b/sessions/working-with-people/enterprise-level-data-science-success.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/prabhakar1978
     linkedin: https://www.linkedin.com/in/prabhakart/
     affiliation: https://flex.com/
-  username: prabhakar-thanikasalam
+  username: prabhakar_thanikasalam
   photo: /assets/img/2022Conf/_talks/22169_prabhakar-thanikasalam.jpg
   bio: |+
     Prabhakar (Prabha) Thanikasalam has 16+ years of experience in data,

--- a/sessions/working-with-people/enterprise-level-data-science-success.md
+++ b/sessions/working-with-people/enterprise-level-data-science-success.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/prabhakar1978
     linkedin: https://www.linkedin.com/in/prabhakart/
     affiliation: https://flex.com/
-  slug: prabhakar-thanikasalam
+  username: prabhakar-thanikasalam
   photo: /assets/img/2022Conf/_talks/22169_prabhakar-thanikasalam.jpg
   bio: |+
     Prabhakar (Prabha) Thanikasalam has 16+ years of experience in data,

--- a/sessions/working-with-people/how-to-be-pollinator.md
+++ b/sessions/working-with-people/how-to-be-pollinator.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/weihuangwong
     linkedin: ~
     affiliation: https://www.norc.org/
-  slug: weihuang-wong
+  username: weihuang-wong
   photo: /assets/img/2022Conf/_talks/22075_weihuang-wong.jpg
   bio: |+
     Weihuang (Wei) Wong is a Senior Research Methodologist at NORC, where
@@ -38,7 +38,7 @@ speakers:
     github: https://github.com/kiegan
     linkedin: ~
     affiliation: https://www.norc.org/Pages/default.aspx
-  slug: kiegan-rice
+  username: kiegan-rice
   photo: /assets/img/2022Conf/_talks/22075_kiegan-rice.jpg
   bio: |+
     Kiegan is a Statistician at NORC at the University of Chicago

--- a/sessions/working-with-people/how-to-be-pollinator.md
+++ b/sessions/working-with-people/how-to-be-pollinator.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/weihuangwong
     linkedin: ~
     affiliation: https://www.norc.org/
-  username: weihuang-wong
+  username: weihuang_wong
   photo: /assets/img/2022Conf/_talks/22075_weihuang-wong.jpg
   bio: |+
     Weihuang (Wei) Wong is a Senior Research Methodologist at NORC, where
@@ -38,7 +38,7 @@ speakers:
     github: https://github.com/kiegan
     linkedin: ~
     affiliation: https://www.norc.org/Pages/default.aspx
-  username: kiegan-rice
+  username: kiegan_rice
   photo: /assets/img/2022Conf/_talks/22075_kiegan-rice.jpg
   bio: |+
     Kiegan is a Statistician at NORC at the University of Chicago

--- a/sessions/wtf-career/journey-to-becoming-apache-arrow.md
+++ b/sessions/wtf-career/journey-to-becoming-apache-arrow.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/thisisnic/
     linkedin: ~
     affiliation: ~
-  username: nic-crane
+  username: nic_crane
   photo: /assets/img/2022Conf/_talks/22048_nic-crane.jpg
   bio: |+
     Nic Crane is an R developer, educator, and general enthusiast. They

--- a/sessions/wtf-career/journey-to-becoming-apache-arrow.md
+++ b/sessions/wtf-career/journey-to-becoming-apache-arrow.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/thisisnic/
     linkedin: ~
     affiliation: ~
-  slug: nic-crane
+  username: nic-crane
   photo: /assets/img/2022Conf/_talks/22048_nic-crane.jpg
   bio: |+
     Nic Crane is an R developer, educator, and general enthusiast. They

--- a/sessions/wtf-career/wtf-teach-you-industry.md
+++ b/sessions/wtf-career/wtf-teach-you-industry.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/tgerke/
     linkedin: https://www.linkedin.com/in/travisgerke/
     affiliation: https://pcctc.org/
-  username: travis-gerke
+  username: travis_gerke
   photo: /assets/img/2022Conf/_talks/22165_travis-gerke.jpg
   bio: |+
     As academic faculty, I led cancer-focused research teams in the

--- a/sessions/wtf-career/wtf-teach-you-industry.md
+++ b/sessions/wtf-career/wtf-teach-you-industry.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/tgerke/
     linkedin: https://www.linkedin.com/in/travisgerke/
     affiliation: https://pcctc.org/
-  slug: travis-gerke
+  username: travis-gerke
   photo: /assets/img/2022Conf/_talks/22165_travis-gerke.jpg
   bio: |+
     As academic faculty, I led cancer-focused research teams in the

--- a/sessions/wtf-career/wtf-teach-you-starting-business.md
+++ b/sessions/wtf-career/wtf-teach-you-starting-business.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/dgkeyes
     linkedin: https://www.linkedin.com/in/dgkeyes/
     affiliation: https://rfortherestofus.com
-  slug: david-keyes
+  username: david-keyes
   photo: /assets/img/2022Conf/_talks/22037_david-keyes.jpg
   bio: |+
     David Keyes is the CEO and founder of R for the Rest of Us. Since

--- a/sessions/wtf-career/wtf-teach-you-starting-business.md
+++ b/sessions/wtf-career/wtf-teach-you-starting-business.md
@@ -21,7 +21,7 @@ speakers:
     github: https://github.com/dgkeyes
     linkedin: https://www.linkedin.com/in/dgkeyes/
     affiliation: https://rfortherestofus.com
-  username: david-keyes
+  username: david_keyes
   photo: /assets/img/2022Conf/_talks/22037_david-keyes.jpg
   bio: |+
     David Keyes is the CEO and founder of R for the Rest of Us. Since


### PR DESCRIPTION
Since sched is the primary display, I've renamed the `slug` key for a speaker to `username` and ensured that it matches the username on sched for everyone.

This also resolves the issues with a handful of speakers. Some needed unique usernames, in which case I used available social media account names. Others already had accounts with sched and I've updated their roles appropriately. (This isn't automated by can be done manually with `sched_user_mod_speaker_role()`.)

I fixed #10 in the process. Note that speakers only need to add info in one place, ideally the talk they're primarily presenting. In other places, their full name and username will suffice. (If we move to static pages on rstudio.com I'll need to revisit this decision.)