### PR TITLE
change talk title

### DIFF
--- a/sessions/shiny-app-design/whats-new-in-shiny-ui.md
+++ b/sessions/shiny-app-design/whats-new-in-shiny-ui.md
@@ -7,9 +7,9 @@ talk_tags: [design, html/css/js, shiny]
 session_slug: shiny-app-design
 # ---- Edit information below this line ----
 # The title of your talk
-talk_title: "What's new in Shiny UI"
+talk_title: "Designing for people is hard"
 # A short version of the title, suitable for small displays
-talk_title_short: What's new in Shiny UI
+talk_title_short: Designing for people is hard
 # A link to your talk's materials, when ready
 talk_materials_url: ~
 speakers:


### PR DESCRIPTION
You know what's boring? "What's new in Shiny UI" as a talk title.  So I'm adding some spice that more accurately describes my talk.