### PR TITLE
Finalize "The Past and Future of Shiny" keynote bio/abstract

### DIFF
--- a/sessions/keynote/past-future-shiny.md
+++ b/sessions/keynote/past-future-shiny.md
@@ -17,14 +17,16 @@ speakers:
   affiliation: RStudio, PBC
   url:
     webpage: ~
-    twitter: ~
+    twitter: https://twitter.com/jcheng
     github: https://github.com/jcheng5
     linkedin: ~
     affiliation: ~
   username: joe_cheng.1v84pjmc
   photo: /assets/img/2022Conf/_talks/22302_joe-cheng.jpeg
   bio: |+
-    NA
+    Joe Cheng is the Chief Technology Officer at RStudio and was the original
+    creator of the Shiny web framework, and continues to work on packages at the
+    intersection of R and the web.
 
 
 ---

--- a/sessions/keynote/past-future-shiny.md
+++ b/sessions/keynote/past-future-shiny.md
@@ -3,7 +3,7 @@
 talk_id: 22302
 talk_slug: past-future-shiny
 talk_type: keynote
-talk_tags: ~
+talk_tags: [shiny, story]
 session_slug: keynote
 # ---- Edit information below this line ----
 # The title of your talk


### PR DESCRIPTION
Hi @jcheng5! We'd like to publish your talk abstract (and your bio) in the conf program. I've started things off by adding your bio from https://www.rstudio.com/authors/joe-cheng/. It's likely out of date so please edit it as needed. The talk abstract can be added in the body of the markdown file (`sessions/keynote/past-future-shiny.md`).
